### PR TITLE
Increase line height for masthead h1s

### DIFF
--- a/style/css/layout.css
+++ b/style/css/layout.css
@@ -484,8 +484,8 @@ section,
 .masthead-l .page-title,
 .masthead-s .page-title {
     font-size: 57px;
-    line-height: 65px;
-    line-height: 4.0625rem;
+    line-height: 80px;
+    line-height: 5rem;
     margin-top: 1.5625rem;
     margin-top: 25px;
     }


### PR DESCRIPTION
The line-height was pretty tight for multi-line headers in our masthead on desktop/tablet. I opened it up a bit to so it doesn't look squished together.

Before:
![image](https://cloud.githubusercontent.com/assets/6456757/5211611/efff27b6-759a-11e4-8603-4fc5eca79157.png)

With changes:

![image](https://cloud.githubusercontent.com/assets/6456757/5211623/2211478e-759b-11e4-8965-17fea328cc39.png)
