### PR TITLE
Add bottom margin to layout-crochet

### DIFF
--- a/style/css/layout.css
+++ b/style/css/layout.css
@@ -56,6 +56,7 @@ blockquote {
     .layout-grid-crotchet > div {
         width: 32%;
         float: left;
+        margin: 0 0 2em 0;
         clear: none;
         padding: 0;
         }


### PR DESCRIPTION
Adds bottom margin of 2em to layout-crochet module.

Currently layout-minim (2-col) has a 2em bottom margin, but layout-crochet (3-col) does not. Perhaps there's a reason for this I'm unaware of, but it seems to force some layouts to add unnecessary inline css or extra div's for padding.

---------------

For example, the current http://codeforamerica.org/about page:

![image](https://cloud.githubusercontent.com/assets/6456757/5274022/53c4bdd0-7a44-11e4-8110-aba4202554bd.png)

A /governments/ layout I'm working on:

![image](https://cloud.githubusercontent.com/assets/6456757/5274107/40b29f9a-7a45-11e4-8f51-007ee32f04ec.png)

Both of these use the same wrapper format...

    <section class="slab-red">
      <div class="layout-breve">
        <div class="layout-crochet">
          <!-- CONTENT -->
        </div>
      </div>
    </section>

or

    <section class="slab-red">
      <div class="layout-breve">
        <div class="layout-minim">
          <!-- CONTENT -->
        </div>
      </div>
    </section>