### PR TITLE
Create fellowship disambiguation page

### DIFF
--- a/about/fellowship/index.html
+++ b/about/fellowship/index.html
@@ -1,0 +1,141 @@
+---
+layout: default
+title: Fellowship
+nav_tier1_active: "about"
+masthead-image: "../../media/images/about_fellowship/fellowshipprogram.jpg"
+nav-breadcrumbs:
+ - Who We Are: "/about"
+ - Fellowship: "/about/fellowship"
+---
+
+        <section>
+            <div class="layout-semibreve layout-centered">
+                <p><h2 class="isolate">Program Overview</h2>
+
+                The Fellowship is a service-year program where civic-minded developers, designers, and product managers create small startup teams and partner with a local government for a year-long collaboration.</p>
+
+                <p>Fellows and government staff work together to build apps, foster new approaches to problem solving throughout City Hall, and tackle issues the community is facing. In the past, teams have worked on solving for access to social services, alternatives to incarceration, and new avenues for public input.</p>
+                
+                <p><b>Are you a government employee looking for info?</b> Contact <a href="mailto:luke@codeforamerica.org">Luke D. Norris</a>, Government Relations Director</p>
+                </div>
+        </section>
+
+        <section class="slab-red">
+
+  <div class="layout-centered xx-pattern-layout">
+            	<div class="layout-breve">
+    	            <div class="layout-crotchet">
+    	            	<div class="layout-breve slab-medium-red" style="margin-left-value:5px;">
+    	            		<h3>2015 Partners</h3>
+    	                	<p align=left>The 2015 Code for America fellowship class will work in service of eight communities across the country. 
+</p> 
+    	            			<a href="http://www.codeforamerica.org/governments/2015-cities/" class="button wodge-button">Learn more</a>
+    	            	</div>
+    	            </div>
+    	            <div class="layout-crotchet">
+    	            <div class="layout-breve slab-medium-red">
+    	                <h3>2015 Fellows</h3>
+    	                <p align=left>Twenty-four fellows will leave jobs at tech companies, their own businesses, and government, to pursue a year of using their skills for the public good.</p>
+                    		<a href="http://www.codeforamerica.org/geeks/our-geeks/2015-fellows/" class="button wodge-button">Meet them</a>
+                    	
+                    </div>
+    	            </div>
+    	            <div class="layout-crotchet">
+    	            <div class="layout-breve slab-medium-red">
+    	                <h3>Announcing the 2015 Fellows</h3>
+    	                <p align=left>Nicole Neditch, Code for America Fellowship Director, welcomes the 2015 cohort to the Code for America community</p>
+    	            		<a href="http://www.codeforamerica.org/blog/2014/11/20/announcing-the-2015-fellows" class="button wodge-button">Read more</a>
+    	            	 </div>
+    	            </div>
+    	        </div>
+            </div>
+   
+</section>
+        <section>
+            <div class="layout-breve">
+                <div class="layout-crotchet-staccato">
+                    <h3 class="heading-contrast">For <strong>Citizens</strong></h3>
+
+                    <ul class="list-ruled">
+                        <li>Use your skills for good. <a href="../../geeks/fellowship-apply/">Become a Fellow</a>.</li>
+
+                        <li>Guide and advise Fellows. <a href="../../mentor">Become a Mentor</a>.</li>
+                        
+                        <li>Read about about the Fellows from <a href="http://codeforamerica.org/geeks/our-geeks/2014-fellows/">2014</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2013-fellows/">2013</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2012-fellows/">2012</a> and <a href="http://codeforamerica.org/geeks/our-geeks/2011-fellows/">2011</a>
+                    </ul>
+                </div>
+
+                <div class="layout-crotchet-staccato">
+                    <h3 class="heading-contrast">For <strong>Governments</strong></h3>
+
+                    <ul class="list-ruled">
+                        <li>Enlist the Fellows. <a href="../../cities/fellowship-apply">Apply Today</a>.</li>
+
+                        <li>Learn about <a href="http://wiki.civiccommons.org/Open_Data_Guidelines">open data best practices</a>.</li>
+                        
+                        <li>Read about the <a href="http://codeforamerica.org/cities/2014-cities/">current</a> and <a href="http://www.codeforamerica.org/cities/alumni/">alumni</a> Fellowship cities.
+                    </ul>
+                </div>
+
+                <div class="layout-crotchet-staccato">
+                    <h3 class="heading-contrast">For <strong>Sponsors</strong></h3>
+
+                    <ul class="list-ruled">
+                        <li><a href="../../support-us">Sponsor</a> a Fellowship in Your City</li>
+
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <section class="slab-gray">
+            <div class="layout-semibreve">
+                <div>
+                    <a name="mentors"></a><h3>Advisors & Mentors</h3>
+
+                    <div>
+                        <table border="0" cellspacing="2" cellpadding="2">
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <p><b>Tom Lee</b>, Sunlight Foundation</p>
+
+                                        <p><b>Thor Muller</b>, Originals</p>
+
+                                        <p><b>Alistair Croll</b>, Author</p>
+
+                                        <p><b>Tim Dierks</b>, Arnold Foundation</p>
+
+                                        <p><b>Parker Thompson</b>, Pivotal</p>
+
+                                        <p><b>Hillary Hoeber</b>, IDEO</p>
+
+                                        <p><b>Rick Klau</b>, Google Ventures</p>
+
+                                        <p><b>Stephanie Hannon</b>, Google</p>
+                                    </td>
+
+                                    <td>
+                                        <p><b>Eric Rodenbeck</b>, Stamen</p>
+
+                                        <p><b>Nadav Savio</b>, Google.org</p>
+
+                                        <p><b>Andrew Crow</b>, GE Design</p>
+
+                                        <p><b>Brian Yeung</b>, SoundCloud</p>
+
+                                        <p><b>Matt Deland</b>, Groupon</p>
+
+                                        <p><b>Ben Sigelman</b>, Stealthmode Startup</p>
+
+                                        <p><b>Thomson Nguyen</b>, Framed Data</p>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+        </section>
+        

--- a/about/fellowship/index.html
+++ b/about/fellowship/index.html
@@ -27,8 +27,8 @@ nav-breadcrumbs:
       
       <p class="heading-contrast"><br />Other ways to get involved:</p>
       <ul class="list-ruled">
-        <li>Guide and advise Fellows. <a href="../../mentor">Become a Mentor</a>.</li>
-        <li>Read about about the Fellows from <a href="http://codeforamerica.org/geeks/our-geeks/2015-fellows/">2015</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2014-fellows/">2014</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2013-fellows/">2013</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2012-fellows/">2012</a> and <a href="http://codeforamerica.org/geeks/our-geeks/2011-fellows/">2011</a>.</li>
+        <li>Guide and advise fellows. <a href="../../mentor">Become a Mentor</a>.</li>
+        <li>Read about about the fellows from <a href="http://codeforamerica.org/geeks/our-geeks/2015-fellows/">2015</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2014-fellows/">2014</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2013-fellows/">2013</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2012-fellows/">2012</a> and <a href="http://codeforamerica.org/geeks/our-geeks/2011-fellows/">2011</a>.</li>
       </ul>
     </div><!-- ./layout-minim -->
 
@@ -40,7 +40,7 @@ nav-breadcrumbs:
       <p class="heading-contrast"><br />Other ways to get involved:</p>
       <ul class="list-ruled">
         <li>Learn about <a href="http://www.codeforamerica.org/governments/principles/open-data/">open data best practices</a>.</li>
-        <li>Read about the <a href="http://codeforamerica.org/cities/2015-cities/">current</a> and <a href="http://www.codeforamerica.org/cities/alumni/">alumni</a> Fellowship cities.
+        <li>Read about the <a href="http://codeforamerica.org/cities/2015-cities/">current</a> and <a href="http://www.codeforamerica.org/cities/alumni/">alumni</a> fellowship cities.
       </ul>
     </div><!-- ./layout-minim -->
 

--- a/about/fellowship/index.html
+++ b/about/fellowship/index.html
@@ -8,134 +8,96 @@ nav-breadcrumbs:
  - Fellowship: "/about/fellowship"
 ---
 
-        <section>
-            <div class="layout-semibreve layout-centered">
-                <p><h2 class="isolate">Program Overview</h2>
+<section class="slab-red">
+  <div class="layout-semibreve layout-centered">
+    <h2>Showing What’s Possible</h2>
 
-                The Fellowship is a service-year program where civic-minded developers, designers, and product managers create small startup teams and partner with a local government for a year-long collaboration.</p>
-
-                <p>Fellows and government staff work together to build apps, foster new approaches to problem solving throughout City Hall, and tackle issues the community is facing. In the past, teams have worked on solving for access to social services, alternatives to incarceration, and new avenues for public input.</p>
-                
-                <p><b>Are you a government employee looking for info?</b> Contact <a href="mailto:luke@codeforamerica.org">Luke D. Norris</a>, Government Relations Director</p>
-                </div>
-        </section>
-
-        <section class="slab-red">
-
-  <div class="layout-centered xx-pattern-layout">
-            	<div class="layout-breve">
-    	            <div class="layout-crotchet">
-    	            	<div class="layout-breve slab-medium-red" style="margin-left-value:5px;">
-    	            		<h3>2015 Partners</h3>
-    	                	<p align=left>The 2015 Code for America fellowship class will work in service of eight communities across the country. 
-</p> 
-    	            			<a href="http://www.codeforamerica.org/governments/2015-cities/" class="button wodge-button">Learn more</a>
-    	            	</div>
-    	            </div>
-    	            <div class="layout-crotchet">
-    	            <div class="layout-breve slab-medium-red">
-    	                <h3>2015 Fellows</h3>
-    	                <p align=left>Twenty-four fellows will leave jobs at tech companies, their own businesses, and government, to pursue a year of using their skills for the public good.</p>
-                    		<a href="http://www.codeforamerica.org/geeks/our-geeks/2015-fellows/" class="button wodge-button">Meet them</a>
-                    	
-                    </div>
-    	            </div>
-    	            <div class="layout-crotchet">
-    	            <div class="layout-breve slab-medium-red">
-    	                <h3>Announcing the 2015 Fellows</h3>
-    	                <p align=left>Nicole Neditch, Code for America Fellowship Director, welcomes the 2015 cohort to the Code for America community</p>
-    	            		<a href="http://www.codeforamerica.org/blog/2014/11/20/announcing-the-2015-fellows" class="button wodge-button">Read more</a>
-    	            	 </div>
-    	            </div>
-    	        </div>
-            </div>
-   
+    <p>The Fellowship is a service-year program where civic-minded developers, designers, and product managers create small startup teams and partner with a local government for a year-long collaboration.</p>
+    <p>Fellows and government staff work together to build apps, foster new approaches to problem solving throughout City Hall, and tackle issues the community is facing.</p>
+    <!--     <p><strong>Are you a government employee looking for info?</strong> Contact <a href="mailto:luke@codeforamerica.org">Luke D. Norris</a>, Government Relations Director</p> -->
+  </div>
 </section>
-        <section>
-            <div class="layout-breve">
-                <div class="layout-crotchet-staccato">
-                    <h3 class="heading-contrast">For <strong>Citizens</strong></h3>
 
-                    <ul class="list-ruled">
-                        <li>Use your skills for good. <a href="../../geeks/fellowship-apply/">Become a Fellow</a>.</li>
+<section>
+  <div class="layout-breve">
 
-                        <li>Guide and advise Fellows. <a href="../../mentor">Become a Mentor</a>.</li>
-                        
-                        <li>Read about about the Fellows from <a href="http://codeforamerica.org/geeks/our-geeks/2014-fellows/">2014</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2013-fellows/">2013</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2012-fellows/">2012</a> and <a href="http://codeforamerica.org/geeks/our-geeks/2011-fellows/">2011</a>
-                    </ul>
-                </div>
+    <div class="layout-minim">
+      <p class="heading-contrast">For citizens</p>
+      <h3>I want to become a Fellow</h3>
+      <p>Fellows have inspired creativity, collaboration, and new approaches to problem solving in local governments across the country. Join the cause.</p>
+      <a class="button" href="/geeks/fellowship-apply">Become a Fellow</a>
+      
+      <p class="heading-contrast"><br />Other ways to get involved:</p>
+      <ul class="list-ruled">
+        <li>Guide and advise Fellows. <a href="../../mentor">Become a Mentor</a>.</li>
+        <li>Read about about the Fellows from <a href="http://codeforamerica.org/geeks/our-geeks/2015-fellows/">2015</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2014-fellows/">2014</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2013-fellows/">2013</a>, <a href="http://codeforamerica.org/geeks/our-geeks/2012-fellows/">2012</a> and <a href="http://codeforamerica.org/geeks/our-geeks/2011-fellows/">2011</a>.</li>
+      </ul>
+    </div><!-- ./layout-minim -->
 
-                <div class="layout-crotchet-staccato">
-                    <h3 class="heading-contrast">For <strong>Governments</strong></h3>
+    <div class="layout-minim">
+      <p class="heading-contrast">For governments</p>
+      <h3>I want to enlist the Fellows</h3>
+      <p>Applications to become a 2016 Fellowship government partner open soon. Get caught up on the program and start a conversation with us.</p>
+      <a class="button" href="/governments/fellowship">Enlist the Fellows</a>
 
-                    <ul class="list-ruled">
-                        <li>Enlist the Fellows. <a href="../../cities/fellowship-apply">Apply Today</a>.</li>
+      <p class="heading-contrast"><br />Other ways to get involved:</p>
+      <ul class="list-ruled">
+        <li>Learn about <a href="http://www.codeforamerica.org/governments/principles/open-data/">open data best practices</a>.</li>
+        <li>Read about the <a href="http://codeforamerica.org/cities/2015-cities/">current</a> and <a href="http://www.codeforamerica.org/cities/alumni/">alumni</a> Fellowship cities.
+      </ul>
+    </div><!-- ./layout-minim -->
 
-                        <li>Learn about <a href="http://wiki.civiccommons.org/Open_Data_Guidelines">open data best practices</a>.</li>
-                        
-                        <li>Read about the <a href="http://codeforamerica.org/cities/2014-cities/">current</a> and <a href="http://www.codeforamerica.org/cities/alumni/">alumni</a> Fellowship cities.
-                    </ul>
-                </div>
+  </div><!-- ./layout-breve -->
+</section>
 
-                <div class="layout-crotchet-staccato">
-                    <h3 class="heading-contrast">For <strong>Sponsors</strong></h3>
+<!-- 
+<section class="slab-gray">
+  <div class="layout-semibreve">
+    <div>
+      <a name="mentors"></a><h3>Advisors & Mentors</h3>
 
-                    <ul class="list-ruled">
-                        <li><a href="../../support-us">Sponsor</a> a Fellowship in Your City</li>
+      <div>
+        <table border="0" cellspacing="2" cellpadding="2">
+          <tbody>
+            <tr>
+              <td>
+                <p><b>Tom Lee</b>, Sunlight Foundation</p>
 
-                    </ul>
-                </div>
-            </div>
-        </section>
+                <p><b>Thor Muller</b>, Originals</p>
 
-        <section class="slab-gray">
-            <div class="layout-semibreve">
-                <div>
-                    <a name="mentors"></a><h3>Advisors & Mentors</h3>
+                <p><b>Alistair Croll</b>, Author</p>
 
-                    <div>
-                        <table border="0" cellspacing="2" cellpadding="2">
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <p><b>Tom Lee</b>, Sunlight Foundation</p>
+                <p><b>Tim Dierks</b>, Arnold Foundation</p>
 
-                                        <p><b>Thor Muller</b>, Originals</p>
+                <p><b>Parker Thompson</b>, Pivotal</p>
 
-                                        <p><b>Alistair Croll</b>, Author</p>
+                <p><b>Hillary Hoeber</b>, IDEO</p>
 
-                                        <p><b>Tim Dierks</b>, Arnold Foundation</p>
+                <p><b>Rick Klau</b>, Google Ventures</p>
 
-                                        <p><b>Parker Thompson</b>, Pivotal</p>
+                <p><b>Stephanie Hannon</b>, Google</p>
+              </td>
 
-                                        <p><b>Hillary Hoeber</b>, IDEO</p>
+              <td>
+                <p><b>Eric Rodenbeck</b>, Stamen</p>
 
-                                        <p><b>Rick Klau</b>, Google Ventures</p>
+                <p><b>Nadav Savio</b>, Google.org</p>
 
-                                        <p><b>Stephanie Hannon</b>, Google</p>
-                                    </td>
+                <p><b>Andrew Crow</b>, GE Design</p>
 
-                                    <td>
-                                        <p><b>Eric Rodenbeck</b>, Stamen</p>
+                <p><b>Brian Yeung</b>, SoundCloud</p>
 
-                                        <p><b>Nadav Savio</b>, Google.org</p>
+                <p><b>Matt Deland</b>, Groupon</p>
 
-                                        <p><b>Andrew Crow</b>, GE Design</p>
+                <p><b>Ben Sigelman</b>, Stealthmode Startup</p>
 
-                                        <p><b>Brian Yeung</b>, SoundCloud</p>
-
-                                        <p><b>Matt Deland</b>, Groupon</p>
-
-                                        <p><b>Ben Sigelman</b>, Stealthmode Startup</p>
-
-                                        <p><b>Thomson Nguyen</b>, Framed Data</p>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-
-        </section>
-        
+                <p><b>Thomson Nguyen</b>, Framed Data</p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section> 
+-->

--- a/about/fellowship/index.html
+++ b/about/fellowship/index.html
@@ -10,10 +10,9 @@ nav-breadcrumbs:
 
 <section class="slab-red">
   <div class="layout-semibreve layout-centered">
-    <h2>Showing What’s Possible</h2>
+    <h2>About the Fellowship</h2>
 
-    <p>The Fellowship is a service-year program where civic-minded developers, designers, and product managers create small startup teams and partner with a local government for a year-long collaboration.</p>
-    <p>Fellows and government staff work together to build apps, foster new approaches to problem solving throughout City Hall, and tackle issues the community is facing.</p>
+    <p>The Fellowship program sends teams of civic-minded developers, designers, and product managers into local governments across the country to work full-time for a year in partnership with government officials. </p>
     <!--     <p><strong>Are you a government employee looking for info?</strong> Contact <a href="mailto:luke@codeforamerica.org">Luke D. Norris</a>, Government Relations Director</p> -->
   </div>
 </section>
@@ -22,9 +21,8 @@ nav-breadcrumbs:
   <div class="layout-breve">
 
     <div class="layout-minim">
-      <p class="heading-contrast">For citizens</p>
-      <h3>I want to become a Fellow</h3>
-      <p>Fellows have inspired creativity, collaboration, and new approaches to problem solving in local governments across the country. Join the cause.</p>
+      <h3>I Want to Become a Fellow</h3>
+      <p>Fellows inspire creativity, collaboration, and solve problems in local governments across the country.</p>
       <a class="button" href="/geeks/fellowship-apply">Become a Fellow</a>
       
       <p class="heading-contrast"><br />Other ways to get involved:</p>
@@ -35,9 +33,8 @@ nav-breadcrumbs:
     </div><!-- ./layout-minim -->
 
     <div class="layout-minim">
-      <p class="heading-contrast">For governments</p>
-      <h3>I want to enlist the Fellows</h3>
-      <p>Applications to become a 2016 Fellowship government partner open soon. Get caught up on the program and start a conversation with us.</p>
+      <h3>Bring the Fellows to Your Government</h3>
+      <p>Bring a team of technologists to your local government for a year. Applications to become a 2016 Fellowship government partner open soon.</p>
       <a class="button" href="/governments/fellowship">Enlist the Fellows</a>
 
       <p class="heading-contrast"><br />Other ways to get involved:</p>


### PR DESCRIPTION
[Preview the changes here](http://jekit.codeforamerica.org/codeforamerica/codeforamerica.org/fellow-disambig/about/fellowship/)

This resurrects the /about/fellowship page and provides a path for multiple audiences to relevant fellowship pages (i.e. funnels government partners to /governments/fellowship to signal their interest in the fellowship, sends potential fellows to /geeks/fellowship-apply to say they're interested in being a future fellow).

@ZoeBlumenfeld is reviewing content and will give :+1: when it's good to go.