### PR TITLE
Update README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ How to contribute
 
 We need your help to keep our content accurate and up to date. The easiest way for to help is to submit a pull request with one of the below: 
 
-* For members of the community including fellows, brigade captains, and staff, find yourself and your friends in the [big list of people](http://codeforamerica.org/people/) or one of the [lists of civic hackers](http://codeforamerica.org/geeks/our-geeks/) and let us know if your bio is correct and photo current. Personal photos should be about 200 x 200px.
+* For members of the community — including fellows, brigade captains, civic startups, and mentors — find yourself and your friends on one of the [lists of civic hackers](http://codeforamerica.org/geeks/our-geeks/) and let us know if your bio is correct and photo current. For staff, find yourself on the [staff page](http://codeforamerica.org/about/team/) and let us know if your bio is correct and photo current. Personal photos should be about 200 x 200px.
 * If you built an app or project as part of the fellowship or accelerator programs, find it on the [apps page](http://codeforamerica.org/apps) and verify that we’ve got it described accurately.
 * Check government information for brigades and fellowships on the [2014 government partners](http://codeforamerica.org/cities/2014-cities) and [alumni government partners](http://codeforamerica.org/cities/alumni) pages and fill in any blanks you might find.
 * We need quality photos for page headers. Should be about 1200 x 500px, JPG compressed to 150kb max.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We need your help to keep our content accurate and up to date. The easiest way f
 
 * For members of the community — including fellows, brigade captains, civic startups, and mentors — find yourself and your friends on one of the [lists of civic hackers](http://codeforamerica.org/geeks/our-geeks/) and let us know if your bio is correct and photo current. For staff, find yourself on the [staff page](http://codeforamerica.org/about/team/) and let us know if your bio is correct and photo current. Personal photos should be about 200 x 200px.
 * If you built an app or project as part of the fellowship or accelerator programs, find it on the [apps page](http://codeforamerica.org/apps) and verify that we’ve got it described accurately.
-* Check government information for brigades and fellowships on the [2014 government partners](http://codeforamerica.org/cities/2014-cities) and [alumni government partners](http://codeforamerica.org/cities/alumni) pages and fill in any blanks you might find.
+* Check government information for brigades and fellowships on the [2015 government partners](http://codeforamerica.org/cities/2015-cities) and [alumni government partners](http://codeforamerica.org/cities/alumni) pages and fill in any blanks you might find.
 * We need quality photos for page headers. Should be about 1200 x 500px, JPG compressed to 150kb max.
 
 ### <a name="pulls"></a>Submitting a Pull Request


### PR DESCRIPTION
Fixes #842 along with 78a4334.

Updates non-existent links in README to 'big list of people' to point to specific pages for geeks and for staff.

Updates cities link to 2015 cities.

