### PR TITLE
Update redirect for /codeacross/ > /events/codeacross-2015

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -322,7 +322,7 @@ RedirectMatch permanent ^/pages/tools/?$ /2013/07/16/tools-of-the-civic-trade
 RedirectMatch permanent ^/apps/blightstatus/?$ /apps/civicinsight
 RedirectMatch permanent ^/demo/?$ /2012/06/13/demo/
 RedirectMatch permanent ^/jennifer-pahlka-speaks-out/?$ /contact
-RedirectMatch permanent ^/codeacross/?$ /events/codeacross-2014/
+RedirectMatch permanent ^/codeacross/?$ /events/codeacross-2015/
 RedirectMatch permanent ^/code-across-america-2012/?$ /events/codeacross-2012/
 RedirectMatch permanent ^(.*)/pdf/(2011_CfA_Report.*)$ $1/2011-annual-report/$2
 RedirectMatch permanent ^/focus/?$ /our-work/focus-areas

--- a/.test-httpd.py
+++ b/.test-httpd.py
@@ -122,6 +122,7 @@ class TestApache (unittest.TestCase):
                  ('/cities', '/governments/'),
                  ('/cities/2015-partners', '/governments/2015-partners/'),
                  ('/codeacross-2014', '/events/codeacross-2014/'),
+                 ('/codeacross', '/events/codeacross-2015/')
                  ('/02-18-2014', '/peer-network-training/02-18-2014/'),
                  ('/brigade12-12-2013', '/brigade-training/brigade12-12-2013/'),
                  ('/09-19-2013', '/brigade-training/09-19-2013/'),

--- a/.test-httpd.py
+++ b/.test-httpd.py
@@ -122,7 +122,7 @@ class TestApache (unittest.TestCase):
                  ('/cities', '/governments/'),
                  ('/cities/2015-partners', '/governments/2015-partners/'),
                  ('/codeacross-2014', '/events/codeacross-2014/'),
-                 ('/codeacross', '/events/codeacross-2015/')
+                 ('/codeacross', '/events/codeacross-2015/'),
                  ('/02-18-2014', '/peer-network-training/02-18-2014/'),
                  ('/brigade12-12-2013', '/brigade-training/brigade12-12-2013/'),
                  ('/09-19-2013', '/brigade-training/09-19-2013/'),


### PR DESCRIPTION
The /codeacross/ redirect went to the page for last year. Updates so codeforamerica.org/codeacross will redirect this year's page.

Tested locally with .run-httpd and it works.

@migurski please idiot check and merge.

(/cc @mollymcleod who asked for this update)