### PR TITLE
Serve static metadata for the blog

### DIFF
--- a/_includes/meta-header.html
+++ b/_includes/meta-header.html
@@ -1,5 +1,5 @@
 <!-- Place this data between the <head> tags of your website --> 
-<meta name="description" content="Page description. No longer than 155 characters."
+<meta name="description" content="Page description. No longer than 155 characters.">
 
 <!-- Google Authorship and Publisher Markup --> 
 <link rel="author" href="https://plus.google.com/+codeforamerica/posts"/>

--- a/fragments/global-metadata.html
+++ b/fragments/global-metadata.html
@@ -1,0 +1,3 @@
+---
+---
+{% include meta-header.html %}


### PR DESCRIPTION
I'm trying to get the blog to start serving up nice metadata for social sharing/linking. I'm going to serve the static metadata file so I can pull its contents for non-article pages on the blog.

Page will serve from /fragments/global-metadata.html