### PR TITLE
fixed links to blog posts in people profile includes

### DIFF
--- a/_includes/people/aaron-ogle.html
+++ b/_includes/people/aaron-ogle.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/atogle">@atogle</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/atogle">http://github<wbr>.com/<wbr>atogle</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/aaronogle">http://linkedin<wbr>.com/<wbr>in/<wbr>aaronogle</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/aaron/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>aaron/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/aaron/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>aaron/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/alan-palazzolo.html
+++ b/_includes/people/alan-palazzolo.html
@@ -30,7 +30,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/zzolo">@zzolo</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/zzolo">http://github<wbr>.com/<wbr>zzolo</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/alanpalazzolo/">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>alanpalazzolo/</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/alan/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>alan/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/alan/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>alan/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/alan-williams.html
+++ b/_includes/people/alan-williams.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/alanjosephwilli">@alanjosephwilli</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/alanjosephwilliams">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>alanjosephwilliams</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/alanw/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>alanw/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/alanw/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>alanw/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/alex-pandel.html
+++ b/_includes/people/alex-pandel.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/alexpandel">@alexpandel</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/alexpandel">http://linkedin<wbr>.com/<wbr>in/<wbr>alexpandel</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/alexp/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>alexp/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/alexp/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>alexp/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/alex-tran.html
+++ b/_includes/people/alex-tran.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/alexstran">@alexstran</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/alexandersitran">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>alexandersitran</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/atran/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>atran/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/atran/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>atran/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/alex-yule.html
+++ b/_includes/people/alex-yule.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/yuletide">@yuletide</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/alexyule">http://linkedin<wbr>.com/<wbr>in/<wbr>alexyule</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/alexy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>alexy/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/alexy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>alexy/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/alicia-rouault.html
+++ b/_includes/people/alicia-rouault.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/arouault">@arouault</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/alicia-rouault/21/738/a17">http://linkedin<wbr>.com/<wbr>pub/<wbr>alicia-rouault/<wbr>21/<wbr>738/<wbr>a17</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/alicia/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>alicia/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/alicia/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>alicia/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/amir-reavis-bey.html
+++ b/_includes/people/amir-reavis-bey.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/Maromba">@Maromba</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/amirbey">http://linkedin<wbr>.com/<wbr>in/<wbr>amirbey</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/amir/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>amir/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/amir/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>amir/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/andrew-hyder.html
+++ b/_includes/people/andrew-hyder.html
@@ -29,7 +29,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/hackyourcity">@hackyourcity</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/ondrae">http://github<wbr>.com/<wbr>ondrae</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="www.linkedin.com/in/hyd415">www.linkedin.com/in/hyd415</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/andrew-hyder/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>andrew-hyder/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/andrew-hyder/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>andrew-hyder/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/andy-hull.html
+++ b/_includes/people/andy-hull.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/andyhull3">@andyhull3</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/andyhull">http://github<wbr>.com/<wbr>andyhull</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/andy-hull/27/95/678">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>andy-hull/<wbr>27/<wbr>95/<wbr>678</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/andy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>andy/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/andy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>andy/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/anna-bloom.html
+++ b/_includes/people/anna-bloom.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/annabloom">@annabloom</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/anna-bloom/14/984/40">http://linkedin<wbr>.com/<wbr>pub/<wbr>anna-bloom/<wbr>14/<wbr>984/<wbr>40</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/anna/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>anna/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/anna/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>anna/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/anselm-bradford.html
+++ b/_includes/people/anselm-bradford.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/anselmbradford">@anselmbradford</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/anselmbradford">http://github<wbr>.com/<wbr>anselmbradford</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/anselmbradford">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>anselmbradford</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/anselm-bradford/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>anselm-bradford/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/anselm-bradford/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>anselm-bradford/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/ariel-kennan.html
+++ b/_includes/people/ariel-kennan.html
@@ -28,7 +28,7 @@
 	    	<h3 class="text-whisper">Contact</h3>
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/arielmai">@arielmai</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/arielk/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>arielk/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/arielk/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>arielk/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/ashley-meyers.html
+++ b/_includes/people/ashley-meyers.html
@@ -34,7 +34,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/ashleymmeyers">@ashleymmeyers</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/ashleymmeyers">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>ashleymmeyers</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/ashley/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>ashley/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/ashley/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>ashley/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/ben-sheldon.html
+++ b/_includes/people/ben-sheldon.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/bensheldon">@bensheldon</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/bensheldon">http://github<wbr>.com/<wbr>bensheldon</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/bensheldon">http://linkedin<wbr>.com/<wbr>in/<wbr>bensheldon</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/ben/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>ben/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/ben/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>ben/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/bob-sofman.html
+++ b/_includes/people/bob-sofman.html
@@ -26,7 +26,7 @@
 	    	<h3 class="text-whisper">Contact</h3>
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/robert-sofman/7/bb9/452">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>robert-sofman/<wbr>7/<wbr>bb9/<wbr>452</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/bob/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>bob/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/bob/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>bob/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/catherine-bracy.html
+++ b/_includes/people/catherine-bracy.html
@@ -52,7 +52,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/cbracy">@cbracy</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/catherine-bracy/19/84b/350">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>catherine-bracy/<wbr>19/<wbr>84b/<wbr>350</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/catherine-bracy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>catherine-bracy/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/catherine-bracy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>catherine-bracy/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/chacha-sikes.html
+++ b/_includes/people/chacha-sikes.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/chachasikes">@chachasikes</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/chachasikes">http://github<wbr>.com/<wbr>chachasikes</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/chachasikes">http://linkedin<wbr>.com/<wbr>in/<wbr>chachasikes</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/chacha/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>chacha/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/chacha/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>chacha/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/christopher-whitaker.html
+++ b/_includes/people/christopher-whitaker.html
@@ -52,7 +52,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/civicwhitaker">@civicwhitaker</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/christopherwhitaker">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>christopherwhitaker</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/chris-whitaker/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>chris-whitaker/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/chris-whitaker/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>chris-whitaker/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/cj-bryan.html
+++ b/_includes/people/cj-bryan.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/waltz">@waltz</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/waltz">http://github<wbr>.com/<wbr>waltz</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/cj-bryan/6/612/534">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>cj-bryan/<wbr>6/<wbr>612/<wbr>534</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/cj/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>cj/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/cj/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>cj/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/cris-cristina.html
+++ b/_includes/people/cris-cristina.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/criscristina">@criscristina</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/criscristina">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>criscristina</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/cris-cristina/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>cris-cristina/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/cris-cristina/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>cris-cristina/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/cyd-harrell.html
+++ b/_includes/people/cyd-harrell.html
@@ -51,7 +51,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/cydharrell">@cydharrell</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/cydharrell">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>cydharrell</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/cyd-harrell/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>cyd-harrell/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/cyd-harrell/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>cyd-harrell/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/dan-avery.html
+++ b/_includes/people/dan-avery.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/danavery">@danavery</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/danavery0">http://linkedin<wbr>.com/<wbr>in/<wbr>danavery0</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/danavery/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>danavery/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/danavery/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>danavery/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/dana-oshiro.html
+++ b/_includes/people/dana-oshiro.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/danaoshiro">@danaoshiro</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/danaoshiro">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>danaoshiro</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/dana-oshiro/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>dana-oshiro/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/dana-oshiro/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>dana-oshiro/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/dave-guarino.html
+++ b/_includes/people/dave-guarino.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/allafarce">@allafarce</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/daguar">http://github<wbr>.com/<wbr>daguar</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/david-guarino/4/a33/871">http://linkedin<wbr>.com/<wbr>pub/<wbr>david-guarino/<wbr>4/<wbr>a33/<wbr>871</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/dave/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>dave/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/dave/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>dave/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/dharmishta-rood.html
+++ b/_includes/people/dharmishta-rood.html
@@ -51,7 +51,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/Dharmishta">@Dharmishta</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/dharmishta">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>dharmishta</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/dharmishta-rood/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>dharmishta-rood/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/dharmishta-rood/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>dharmishta-rood/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/diana-tran.html
+++ b/_includes/people/diana-tran.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/dianavtran">@dianavtran</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/dianavtran">http://linkedin<wbr>.com/<wbr>in/<wbr>dianavtran</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/diana/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>diana/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/diana/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>diana/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/doneliza-joaquin.html
+++ b/_includes/people/doneliza-joaquin.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/donelizasays">@donelizasays</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/donelizajoaquin">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>donelizajoaquin</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/doneliza/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>doneliza/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/doneliza/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>doneliza/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/eddie-tejeda.html
+++ b/_includes/people/eddie-tejeda.html
@@ -30,7 +30,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/eddietejeda">@eddietejeda</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/eddietejeda">http://github<wbr>.com/<wbr>eddietejeda</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/profile/view?id=2530266">http://www<wbr>.linkedin<wbr>.com/<wbr>profile/<wbr>view?id=2530266</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/eddie/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>eddie/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/eddie/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>eddie/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/elizabeth-hunt.html
+++ b/_includes/people/elizabeth-hunt.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/ezoehunt">@ezoehunt</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/ezoehunt">http://linkedin<wbr>.com/<wbr>in/<wbr>ezoehunt</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/liz/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>liz/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/liz/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>liz/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/emily-wright-moore.html
+++ b/_includes/people/emily-wright-moore.html
@@ -26,7 +26,7 @@
 	    	<h3 class="text-whisper">Contact</h3>
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/emilyville">@emilyville</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/emily/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>emily/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/emily/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>emily/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/erica-kwan.html
+++ b/_includes/people/erica-kwan.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/pui_ling">@pui_ling</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/pui">http://github<wbr>.com/<wbr>pui</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/ericakwan">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>ericakwan</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/erica-kwan/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>erica-kwan/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/erica-kwan/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>erica-kwan/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/erik-michaels-ober.html
+++ b/_includes/people/erik-michaels-ober.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/sferik">@sferik</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/sferik">http://github<wbr>.com/<wbr>sferik</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/sferik">http://linkedin<wbr>.com/<wbr>in/<wbr>sferik</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/erik/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>erik/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/erik/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>erik/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/ezra-spier.html
+++ b/_includes/people/ezra-spier.html
@@ -41,7 +41,7 @@
                 <tr><th>Twitter</th><td><a href="https://twitter.com/ahhrrr">@ahhrrr</a></td></tr>
                 <tr><th>Github</th><td><a href="http://github.com/ahhrrr">http://github<wbr>.com/<wbr>ahhrrr</a></td></tr>
                 <tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/ezraspier">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>ezraspier</a></td></tr>
-                <tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/ezra/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>ezra/</a></td></tr>
+                <tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/ezra/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>ezra/</a></td></tr>
             </table>
         </div>
     </div>

--- a/_includes/people/hannah-young.html
+++ b/_includes/people/hannah-young.html
@@ -52,7 +52,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/HannahDotYoung">@HannahDotYoung</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="www.linkedin.com/pub/hannah-young/28/454/909">www.linkedin.com/pub/hannah-young/28/454/909</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/hannah-young/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>hannah-young/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/hannah-young/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>hannah-young/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jack-madans.html
+++ b/_includes/people/jack-madans.html
@@ -51,7 +51,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/jackmadans">@jackmadans</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/jack-madans/38/407/51a">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>jack-madans/<wbr>38/<wbr>407/<wbr>51a</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jmadans/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jmadans/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jmadans/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jmadans/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jacob-solomon.html
+++ b/_includes/people/jacob-solomon.html
@@ -52,7 +52,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/lippytak">@lippytak</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/jake-solomon/4/9b7/a70">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>jake-solomon/<wbr>4/<wbr>9b7/<wbr>a70</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jacob/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jacob/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jacob/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jacob/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jeffrey-johnson.html
+++ b/_includes/people/jeffrey-johnson.html
@@ -26,7 +26,7 @@
 	    <div class="spotlight">
 	    	<h3 class="text-whisper">Contact</h3>
 	    	<table class="table-unstyled table-minor">
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jeffrey-johnson/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jeffrey-johnson/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jeffrey-johnson/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jeffrey-johnson/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jennifer-pahlka.html
+++ b/_includes/people/jennifer-pahlka.html
@@ -140,7 +140,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/pahlkadot">@pahlkadot</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/jpahlka">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>jpahlka</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jen/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jen/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jen/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jen/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jeremy-canfield.html
+++ b/_includes/people/jeremy-canfield.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/cdjeremy">@cdjeremy</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/jeremycanfield">http://linkedin<wbr>.com/<wbr>in/<wbr>jeremycanfield</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jeremy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jeremy/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jeremy/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jeremy/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jesse-bounds.html
+++ b/_includes/people/jesse-bounds.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/boundsj">@boundsj</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/boundsj">http://github<wbr>.com/<wbr>boundsj</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/jessebounds">http://linkedin<wbr>.com/<wbr>in/<wbr>jessebounds</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jesse/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jesse/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jesse/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jesse/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jessica-lord.html
+++ b/_includes/people/jessica-lord.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/jllord">@jllord</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/jlord">http://github<wbr>.com/<wbr>jlord</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jessica/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jessica/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jessica/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jessica/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/jim-craner.html
+++ b/_includes/people/jim-craner.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/jimcraner">@jimcraner</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/jim-craner/5/a9/533">http://linkedin<wbr>.com/<wbr>pub/<wbr>jim-craner/<wbr>5/<wbr>a9/<wbr>533</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/jim/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>jim/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/jim/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>jim/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/joe-merante.html
+++ b/_includes/people/joe-merante.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/joemerante">@joemerante</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="www.linkedin.com/in/joemerante">www.linkedin.com/in/joemerante</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/joe/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>joe/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/joe/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>joe/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/joel-mahoney.html
+++ b/_includes/people/joel-mahoney.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/joelmahoney">@joelmahoney</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/joelmahoney">http://github<wbr>.com/<wbr>joelmahoney</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/joelmahoney">http://linkedin<wbr>.com/<wbr>in/<wbr>joelmahoney</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/joel/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>joel/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/joel/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>joel/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/john-lilly.html
+++ b/_includes/people/john-lilly.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/johnolilly">@johnolilly</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/johnlilly">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>johnlilly</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/johnl/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>johnl/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/johnl/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>johnl/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/john-mertens.html
+++ b/_includes/people/john-mertens.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mertonium">@mertonium</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/mertonium">http://github<wbr>.com/<wbr>mertonium</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/johnmertens">http://linkedin<wbr>.com/<wbr>in/<wbr>johnmertens</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/john/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>john/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/john/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>john/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/karla-macedo.html
+++ b/_includes/people/karla-macedo.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/kmimagine">@kmimagine</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/karla-macedo/12/a57/95a">http://linkedin<wbr>.com/<wbr>pub/<wbr>karla-macedo/<wbr>12/<wbr>a57/<wbr>95a</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/karla/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>karla/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/karla/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>karla/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/kevin-curry.html
+++ b/_includes/people/kevin-curry.html
@@ -29,7 +29,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/kmcurry">@kmcurry</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/kmcurry">http://github<wbr>.com/<wbr>kmcurry</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/kevincurry">http://linkedin<wbr>.com/<wbr>in/<wbr>kevincurry</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/kevin/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>kevin/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/kevin/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>kevin/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/laura-meixell.html
+++ b/_includes/people/laura-meixell.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/lauratypes">@lauratypes</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/laura-meixell/2a/787/504">http://linkedin<wbr>.com/<wbr>pub/<wbr>laura-meixell/<wbr>2a/<wbr>787/<wbr>504</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/laura/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>laura/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/laura/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>laura/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/lauren-dyson.html
+++ b/_includes/people/lauren-dyson.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/ladyson">@ladyson</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/ladyson">http://github<wbr>.com/<wbr>ladyson</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/lauren-dyson/a/2ab/3">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>lauren-dyson/<wbr>a/<wbr>2ab/3</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/lauren/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>lauren/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/lauren/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>lauren/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/lauren-reid.html
+++ b/_includes/people/lauren-reid.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/ellereider">@ellereider</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="www.linkedin.com/in/ellereider">www.linkedin.com/in/ellereider</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/lr/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>lr/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/lr/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>lr/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/lou-huang.html
+++ b/_includes/people/lou-huang.html
@@ -29,7 +29,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/saikofish">@saikofish</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/louh">http://github<wbr>.com/<wbr>louh</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/louhuang">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>louhuang</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/lou-huang/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>lou-huang/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/lou-huang/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>lou-huang/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/luke-norris.html
+++ b/_includes/people/luke-norris.html
@@ -51,7 +51,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/norrisluke">@norrisluke</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="www.linkedin.com/in/lukednorris">www.linkedin.com/in/lukednorris</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/luke-norris/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>luke-norris/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/luke-norris/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>luke-norris/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/marc-hebert.html
+++ b/_includes/people/marc-hebert.html
@@ -28,7 +28,7 @@
 	    	<h3 class="text-whisper">Contact</h3>
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/anthromarc">@anthromarc</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/marc/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>marc/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/marc/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>marc/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/matt-boitano.html
+++ b/_includes/people/matt-boitano.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mattboitan0">@mattboitan0</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/mattboitano">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>mattboitano</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/mattb/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>mattb/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/mattb/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>mattb/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/matt-lewis.html
+++ b/_includes/people/matt-lewis.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mattlewissf">@mattlewissf</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/matt-lewis/1b/861/a84">http://linkedin<wbr>.com/<wbr>pub/<wbr>matt-lewis/<wbr>1b/<wbr>861/<wbr>a84</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/matt/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>matt/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/matt/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>matt/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/meghan-reilly.html
+++ b/_includes/people/meghan-reilly.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mfreilly">@mfreilly</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/mfreilly">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>mfreilly</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/mreilly/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>mreilly/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/mreilly/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>mreilly/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/michael-lawrence-evans.html
+++ b/_includes/people/michael-lawrence-evans.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/evansml">@evansml</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/mlevans">http://github<wbr>.com/<wbr>mlevans</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/mlevans">http://linkedin<wbr>.com/<wbr>in/<wbr>mlevans</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/michael/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>michael/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/michael/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>michael/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/michelle-koeth.html
+++ b/_includes/people/michelle-koeth.html
@@ -29,7 +29,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/michellekoeth">@michellekoeth</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="www.linkedin.com/in/mkoeth/">www.linkedin.com/in/mkoeth/</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/michelle/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>michelle/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/michelle/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>michelle/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/michelle-lee.html
+++ b/_includes/people/michelle-lee.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mishmosh">@mishmosh</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/michellelee3">http://linkedin<wbr>.com/<wbr>in/<wbr>michellelee3</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/michelle-lee/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>michelle-lee/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/michelle-lee/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>michelle-lee/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/mick-thompson.html
+++ b/_includes/people/mick-thompson.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/dthompson">@dthompson</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/mick">http://github<wbr>.com/<wbr>mick</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/davidmichaelthompson">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>davidmichaelthompson</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/mick/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>mick/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/mick/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>mick/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/mjumbe-poe.html
+++ b/_includes/people/mjumbe-poe.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mjumbewu">@mjumbewu</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/mjumbewu">http://github<wbr>.com/<wbr>mjumbewu</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/mjumbewu">http://linkedin<wbr>.com/<wbr>in/<wbr>mjumbewu</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/mjumbe/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>mjumbe/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/mjumbe/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>mjumbe/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/nick-doiron.html
+++ b/_includes/people/nick-doiron.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/mapmeld">@mapmeld</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/mapmeld">http://github<wbr>.com/<wbr>mapmeld</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/nickdoiron">http://linkedin<wbr>.com/<wbr>in/<wbr>nickdoiron</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/nickd/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>nickd/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/nickd/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>nickd/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/nicole-neditch.html
+++ b/_includes/people/nicole-neditch.html
@@ -52,7 +52,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/nneditch">@nneditch</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/nicole-neditch/7/b00/194">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>nicole-neditch/<wbr>7/<wbr>b00/<wbr>194</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/nicole/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>nicole/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/nicole/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>nicole/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/nigel-jacob.html
+++ b/_includes/people/nigel-jacob.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/nsjacob">@nsjacob</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/nsjacob">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>nsjacob</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/nigel-jacob/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>nigel-jacob/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/nigel-jacob/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>nigel-jacob/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/noel-hidalgo.html
+++ b/_includes/people/noel-hidalgo.html
@@ -28,7 +28,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/noneck">@noneck</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/noelhidalgo">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>noelhidalgo</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/noel-hidalgo/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>noel-hidalgo/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/noel-hidalgo/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>noel-hidalgo/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/peter-fecteau.html
+++ b/_includes/people/peter-fecteau.html
@@ -29,7 +29,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/peterfecteau">@peterfecteau</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/petefecteau">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>petefecteau</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/peter/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>peter/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/peter/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>peter/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/prashant-singh.html
+++ b/_includes/people/prashant-singh.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/prashtx">@prashtx</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/prashtx">http://github<wbr>.com/<wbr>prashtx</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/prashant-singh/1a/38b/646">http://linkedin<wbr>.com/<wbr>pub/<wbr>prashant-singh/<wbr>1a/<wbr>38b/<wbr>646</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/prashant/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>prashant/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/prashant/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>prashant/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/rebecca-ackerman.html
+++ b/_includes/people/rebecca-ackerman.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/aka_rca">@aka_rca</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/rcackerman">http://github<wbr>.com/<wbr>rcackerman</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/rcackerman">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>rcackerman</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/rebecca/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>rebecca/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/rebecca/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>rebecca/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/richa-agarwal.html
+++ b/_includes/people/richa-agarwal.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/richaaaa">@richaaaa</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/richaagarwal">http://github<wbr>.com/<wbr>richaagarwal</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/richaagarwal">http://linkedin<wbr>.com/<wbr>in/<wbr>richaagarwal</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/richa/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>richa/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/richa/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>richa/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/ryan-closner.html
+++ b/_includes/people/ryan-closner.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/rclosner">@rclosner</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/rclosner">http://github<wbr>.com/<wbr>rclosner</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/ryan-closner/57/9b3/301">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>ryan-closner/<wbr>57/<wbr>9b3/<wbr>301</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/ryanc/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>ryanc/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/ryanc/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>ryanc/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/scott-silverman.html
+++ b/_includes/people/scott-silverman.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/scottsil">@scottsil</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/in/scottsil">http://linkedin<wbr>.com/<wbr>in/<wbr>scottsil</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/scott/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>scott/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/scott/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>scott/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/shaunak-kashyap.html
+++ b/_includes/people/shaunak-kashyap.html
@@ -28,7 +28,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/shaunak">@shaunak</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/ycombinator">http://github<wbr>.com/<wbr>ycombinator</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/ycombinator">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>ycombinator</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/shaunak/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>shaunak/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/shaunak/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>shaunak/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/sheba-najmi.html
+++ b/_includes/people/sheba-najmi.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/snajmi">@snajmi</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/snajmi">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>snajmi</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/sheba/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>sheba/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/sheba/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>sheba/</a></td></tr>
 	    		<tr><th>Video</th><td><a href="https://vimeo.com/51307408">vimeo.com/51307408</a></td></tr>
 
 	    	</table>

--- a/_includes/people/steve-spiker.html
+++ b/_includes/people/steve-spiker.html
@@ -29,7 +29,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/spjika">@spjika</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/spjika">http://github<wbr>.com/<wbr>spjika</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/stevespiker">http://linkedin<wbr>.com/<wbr>stevespiker</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/steve-spiker/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>steve-spiker/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/steve-spiker/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>steve-spiker/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/talin-salway.html
+++ b/_includes/people/talin-salway.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/YenTheFirst">@YenTheFirst</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://linkedin.com/pub/talin-salway/25/717/1a4">http://linkedin<wbr>.com/<wbr>pub/<wbr>talin-salway/<wbr>25/<wbr>717/<wbr>1a4</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/talin/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>talin/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/talin/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>talin/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/tamara-shopsin.html
+++ b/_includes/people/tamara-shopsin.html
@@ -26,7 +26,7 @@
 	    	<h3 class="text-whisper">Contact</h3>
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/crazy1eye">@crazy1eye</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/tamara/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>tamara/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/tamara/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>tamara/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/tim-oreilly.html
+++ b/_includes/people/tim-oreilly.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/timoreilly">@timoreilly</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/pub/tim-o-reilly/0/9/6b5">http://www<wbr>.linkedin<wbr>.com/<wbr>pub/<wbr>tim-o-reilly/<wbr>0/<wbr>9/<wbr>6b5</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/timoreilly/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>timoreilly/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/timoreilly/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>timoreilly/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/tyler-stalder.html
+++ b/_includes/people/tyler-stalder.html
@@ -27,7 +27,7 @@
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/tylerstalder">@tylerstalder</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/tylerstalder">http://github<wbr>.com/<wbr>tylerstalder</a></td></tr>
 	    		<tr><th>LinkedIn</th><td><a href="http://www.linkedin.com/in/tylerstalder">http://www<wbr>.linkedin<wbr>.com/<wbr>in/<wbr>tylerstalder</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/tyler/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>tyler/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/tyler/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>tyler/</a></td></tr>
 
 	    	</table>
 	    </div>

--- a/_includes/people/zach-williams.html
+++ b/_includes/people/zach-williams.html
@@ -27,7 +27,7 @@
 	    	<table class="table-unstyled table-minor">
 	    		<tr><th>Twitter</th><td><a href="https://twitter.com/zachwill">@zachwill</a></td></tr>
 	    		<tr><th>Github</th><td><a href="http://github.com/zachwill">http://github<wbr>.com/<wbr>zachwill</a></td></tr>
-	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/author/zach/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>author/<wbr>zach/</a></td></tr>
+	    		<tr><th>Blog Posts</th><td><a href="http://www.codeforamerica.org/blog/author/zach/">http://www<wbr>.codeforamerica<wbr>.org/<wbr>blog/<wbr>author/<wbr>zach/</a></td></tr>
 
 	    	</table>
 	    </div>


### PR DESCRIPTION
All these links to authors' blog posts on people profiles were broken, resolving to the blog front page. I fixed them by adding `blog/`. I didn't check all the fixed links to verify that they are valid.