### PR TITLE
Add health redirect, fix talent redirect trailing slash

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -333,6 +333,7 @@ RedirectMatch permanent ^/focus/?$ /our-work/focus-areas
 RedirectMatch permanent ^/(FluShotFinder|flu-shot-finder|flushotfinder)$ /apps/flu-shot-finder/
 RedirectMatch permanent ^/projects/new-york-city-hhc-accelerator/?$ /projects/new-york-city-hhs-accelerator/
 RedirectMatch permanent ^/talent/?$ /our-work/initiatives/talent/
+RedirectMatch permanent ^/health/?$ /our-work/focus-areas/health/
 
 #
 # Set of possible Jekyll file extensions + PHP, from

--- a/.test-httpd.py
+++ b/.test-httpd.py
@@ -193,7 +193,8 @@ class TestApache (unittest.TestCase):
                  ('/governments/summit-county', '/governments/summitcounty/'),
                  ('/focus', '/our-work/focus-areas/'),
                  ('/projects/new-york-city-hhc-accelerator/', '/projects/new-york-city-hhs-accelerator/'),
-                 ('/talent/','/our-work/initiatives/talent/')
+                 ('/talent', '/our-work/initiatives/talent/'),
+                 ('/health', '/our-work/focus-areas/health/')
                  
                  # # This actually goes to BSD, but we check for it anyway.
                  # ('/donate', '/page/contribute/default'),


### PR DESCRIPTION
codeforamerica.org/health ---> codeforamerica.org/our-work/focus-areas/health

cc @alanjosephwilliams 
