### PR TITLE
In social metadata, use http

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,4 +2,4 @@ exclude: ['blog', 'library', 'api']
 include: ['.htaccess']
 keep_files: ['blog', 'library', 'brigade', 'api']
 # Used to generate our social metadata
-url-base: "https://codeforamerica.org"
+url-base: "http://codeforamerica.org"


### PR DESCRIPTION
When we force our metadata og:url to be https://codeforamerica.org/*, Facebook gives us this error when it tries to read the metadata off our pages:

```
Curl Error : SSL_PEER_CERTIFICATE SSL: no alternative certificate subject name matches target host name 'codeforamerica.org'
```

Trying to go with http for now for social metadata.