### PR TITLE
Update stories script to produce a GA tracking event, add new stories

### DIFF
--- a/script/home-story.js
+++ b/script/home-story.js
@@ -49,14 +49,18 @@ if(typeof document.createStyleSheet === 'undefined')
 function on_stories(stories)
 {
     var story = stories[Math.floor(Math.random() * stories.length)];
+    var head_html = '<a href="'+story.page_link+'">'+story.title+'</a>';
+    var onclick_event = "ga('send', 'event', 'Homepage', 'Hero link click', 'Story: "+story.title+"');";
 
-    document.getElementById('story-title').innerHTML = story.head_html;
+    document.getElementById('story-title').innerHTML = head_html;
     document.getElementById('story-content').innerHTML = story.content_html;
+    document.getElementById('story-title').getElementsByTagName('a')[0].setAttribute('onclick',onclick_event);
     
-    if(story.hasOwnProperty('box_text') && story.hasOwnProperty('box_link'))
+    if(story.hasOwnProperty('button_text') && story.hasOwnProperty('page_link'))
     {
-        document.getElementById('box-link').href = story.box_link;
-        document.getElementById('box-link').innerHTML = story.box_text;
+        document.getElementById('box-link').href = story.page_link;
+        document.getElementById('box-link').innerHTML = story.button_text;
+        document.getElementById('box-link').setAttribute('onclick',onclick_event);
     }
 
     var s = document.createStyleSheet();

--- a/stories.js
+++ b/stories.js
@@ -31,11 +31,18 @@ on_stories(
     //     "box_text": "Read the announcement"
     // },
     {
-        "head_html": "<a href='governments/fellowship'>Bring the Fellows to you</a>",
-        "content_html": "Bring a team of technologists to your local government for a year.",
-        "image_src": "media/images/about_fellowship/longbeach.jpg",
-        "box_link": "governments/fellowship",
-        "box_text": "Learn more"
+        "page_link"     : "/governments/fellowship",
+        "title"         : "Bring the Fellows to you",
+        "content_html"  : "Bring a team of technologists to your local government for a year.",
+        "image_src"     : "/media/images/about_fellowship/longbeach.jpg",
+        "button_text"   : "Learn more"
+    },
+    {
+        "page_link"     : "/our-work/initiatives/health",
+        "title"         : "Delivering health services with dignity, by default",
+        "content_html"  : "Code for America is partnering with local governments to build digital health services focused on users.",
+        "image_src"     : "/media/images/health/somerville.jpg",
+        "button_text"   : "Learn more"
     }
 ]
 );

--- a/stories.js
+++ b/stories.js
@@ -43,6 +43,20 @@ on_stories(
         "content_html"  : "Code for America is partnering with local governments to build digital health services focused on users.",
         "image_src"     : "/media/images/health/somerville.jpg",
         "button_text"   : "Learn more"
-    }
+    },
+    {
+        "page_link"     : "/summit",
+        "title"         : "Roll up your sleeves at the 2015 CFA Summit",
+        "content_html"  : "For three days, more than 1,300 government leaders, technologists, and community members will delve into how we can transform government together.",
+        "image_src"     : "/media/images/summit/2015/summit-selfie.jpg",
+        "button_text"   : "Join in"
+    },
+    {
+        "page_link"     : "/our-work/initiatives/talent",
+        "title"         : "There has never been a better time to work on technology inside government.",
+        "content_html"  : "Engineers, designers, product managers, data scientists, and more &mdash; put your skills to work in service to your country. Let’s bring government into the 21st century together.",
+        "image_src"     : "/media/images/talent/space.jpg",
+        "button_text"   : "Server your government"
+    },
 ]
 );


### PR DESCRIPTION
This PR updates code and stories for the hero unit at the top of the homepage.

To preview, [open this link and keep refreshing](http://jekit.codeforamerica.org/codeforamerica/codeforamerica.org/add-new-stories/) -- stories are loaded randomly.

### Updates to the generator

I've rewritten the `home-story.js` function a bit to have it add a Google Analytics tracking event on a button or headline click. We can track engagement on the stories.

### New stories added

I've also added new stories for Health (cc @alanjosephwilliams), Summit (cc @mattboitan0), Talent (cc @lanebecker).