### PR TITLE
Updates to ../focus-areas and ../focus-areas/health

### DIFF
--- a/our-work/focus-areas/health/index.html
+++ b/our-work/focus-areas/health/index.html
@@ -250,9 +250,7 @@ description: Code for America partners with local governments to build and grow 
 		<div class="badge-heading badge-github badge-gov" style="border-bottom:none">
 			<h4>Get in touch to learn more.</h4>
 			<p>The Health focus area team includes designers, engineers, domain experts and fellows. <a href="/about/team">Learn about our entire team.</a> Get in touch to learn more about our work and how to deliver health and social services with dignity, by default.</p>
-			<h5>Contact</h5>
-			<p><strong><a href="/people/rebecca-coelius/">Rebecca Coelius, Director of Health</strong></a></p>
-			<p><a href="mailto:rebeccac@codeforamerica.org">rebeccac@codeforamerica.org</a></p>
+			<p>Contact <strong><a href="/people/rebecca-coelius/">Rebecca Coelius, Director of Health</strong></a> at <a href="mailto:rebeccac@codeforamerica.org">rebeccac@codeforamerica.org</a>.</p>
 		</div>
 		<div class="badge-heading badge-github badge-black" style="border-bottom:none">
 			<h4>Data Analyst, Designer or Developer? Get involved right away.</h4>

--- a/our-work/focus-areas/health/index.html
+++ b/our-work/focus-areas/health/index.html
@@ -131,7 +131,7 @@ description: Code for America partners with local governments to build and grow 
 		<div class="layout-minim">
 			<p>Beyond the fellowship, our staff technologists, designers, and researchers experiment and invest over time in high potential digital services.</p>
 			<p>In 2015, we are conducting ongoing research and product development to both improve the user experience and enrollment rate of the Supplemental Nutrition Assistance Program (SNAP) rate in California, building off foundational work done by the San Francisco Fellowship team in 2013.</p>
-			<p>You can follow all of our work on <a href="https://github.com/codeforamerica/health#health">Github</a>, and track our performance against key product indicators on our <a href="https://public.ducksboard.com/NsoSQbe655DQ0DlvQxr6/">public metrics page.</a></p>
+			<p>You can follow all of our work on <a href="https://github.com/codeforamerica/health">Github</a>, and track our performance against key product indicators on our <a href="https://public.ducksboard.com/NsoSQbe655DQ0DlvQxr6/">public metrics page.</a></p>
 		</div>
 		<br>
 		<div class="layout-minim" style="width: 46%; padding-left: 4%;">

--- a/our-work/focus-areas/health/index.html
+++ b/our-work/focus-areas/health/index.html
@@ -119,17 +119,15 @@ description: Code for America partners with local governments to build and grow 
 </section>
 <section>
 	<div class="layout-semibreve">
-		<h3>Partnering with governments to produce original digital services</h3>
+		<h4 class="heading">Original digital services produced with governments</h4>
 		<p><a href="/governments/fellowship/">The Code for America Fellowship Program</a> pairs teams of technologists for a year of deep partnership with a local government and the community  around a new or improved digital service. The output includes an “alpha” product for that digital service, an understanding of the problem space in one community informed by our Peer Network, a local government partner with greater capacity to demonstrate the Principles for 21st Century Government, and strong relationships across the service delivery team that can be leveraged in the future.</p>
 		<figure>
 		    <blockquote>
 		    	<p>We are currently recruiting city and county government partners for 2016 Fellowships! <a href="/governments/fellowship/">Learn more about applying.</a></p>
 		    </blockquote>
 		</figure>
-	</div>
-	<div class="layout-semibreve">
-		<h3>Building and scaling digital services</h3>
 		<br>
+		<h4 class="heading">Building and scaling digital services</h4>
 		<div class="layout-minim">
 			<p>Beyond the fellowship, our staff technologists, designers, and researchers experiment and invest over time in high potential digital services.</p>
 			<p>In 2015, we are conducting ongoing research and product development to both improve the user experience and enrollment rate of the Supplemental Nutrition Assistance Program (SNAP) rate in California, building off foundational work done by the San Francisco Fellowship team in 2013.</p>
@@ -142,50 +140,124 @@ description: Code for America partners with local governments to build and grow 
 				<b>The Big Thing About Small Things:</b> Learn more about the Health Lab's approach and work to date Jake Solomon's talk at the 2014 Code for America Summit.
 			</small>
 		</div>
-		<h5>Ongoing Work</h5>
-		<ul>
-			<li style="list-style:none; background-image:none">
-				<b><a href="http://www.codeforamerica.org/apps/balance/">Balance</a></b>
-				<p>Balance allows people who receive food stamps to check their balance via SMS. Balance brings a little dignity and convenience to the business of managing benefits.</p>
-			</li>
-			<li style="list-style:none; background-image:none">
-				<p><a href="http://www.codeforamerica.org/apps/clean/">Clean</a></p>
-				<p>Clean is a simple and dignified online application for CalFresh. We believe that with a good user experience, thoughtful product marketing and the right partnerships that Clean will be able to meaningfully increase the number of people eligible for CalFresh enrolled in the program.</p>
-			</li>
-			<li style="list-style:none; background-image:none">
-				<b><a href="http://www.codeforamerica.org/apps/connect/">Connect</a></b>
-				<p>Connect helps social service clients and enrollment assisters avoid wasting time on hold. Connect allows users to initiate a call to a social services agency via SMS, and get a call back when a human is on the other line. </p>
-			</li>
-			<li style="list-style:none; background-image:none">
-				<b><a href="http://www.codeforamerica.org/apps/connect/">EBT Near Me</a></b>
+		<br>
+		<h4 class="heading">Our Projects</h4>
+		<ul class="teasers">
+			<li class="layout-crotchet">
+		    	<article class="teaser teaser-app no-logo">
+		        	<header class="teaser-header">
+		            	<a href="http://www.codeforamerica.org/apps/balance/">
+		                	<h1 class="teaser-title">Balance</h1>
+		            	</a>
+		        	</header>
+		        	<div class="teaser-body">
+						<p>Balance allows people who receive food stamps to check their balance via SMS. Balance brings a little dignity and convenience to the business of managing benefits.</p>
+		            	<p><a href="http://www.codeforamerica.org/apps/balance/">Learn more</a></p>
+		        	</div>
+		    	</article>
+		    </li>
+			<li class="layout-crotchet">
+		    	<article class="teaser teaser-app no-logo">
+		        	<header class="teaser-header">
+		            	<a href="http://www.codeforamerica.org/apps/clean/">
+		                	<h1 class="teaser-title">Clean</h1>
+		            	</a>
+		        	</header>
+		        	<div class="teaser-body">
+						<p>Clean is a simple and dignified online application for CalFresh. We believe that with a good user experience, thoughtful product marketing and the right partnerships that Clean will be able to meaningfully increase the number of people eligible for CalFresh enrolled in the program.</p>
+						<p><a href="http://www.codeforamerica.org/apps/clean/">Learn more</a></p>
+		        	</div>
+		    	</article>
+		    </li>
+			<li class="layout-crotchet">
+		    	<article class="teaser teaser-app no-logo">
+		        	<header class="teaser-header">
+		            	<a href="http://www.codeforamerica.org/apps/connect/">
+		                	<h1 class="teaser-title">Connect</h1>
+		            	</a>
+		        	</header>
+		        	<div class="teaser-body">
+		        		<p>Connect helps social service clients and enrollment assisters avoid wasting time on hold. Connect allows users to initiate a call to a social services agency via SMS, and get a call back when a human is on the other line.
+		        		</p>
+						<p><a href="http://www.codeforamerica.org/apps/connect/">Learn more</a></p>
+		        	</div>
+		    	</article>
+		    </li>
+			<li class="layout-crotchet">
+		    	<article class="teaser teaser-app no-logo">
+		        	<header class="teaser-header">
+		            	<a href="http://www.codeforamerica.org/apps/ebtnearme/">
+		                	<h1 class="teaser-title">EBT Near Me</h1>
+		            	</a>
+		        	</header>
+		        	<div class="teaser-body">
 				<p>EBT Near Me helps social service clients find important places they can use their EBT card. On their phone or when first enrolled, people can find ATMs without fees and CalFresh retail locations.
 				</p>
+						<p><a href="http://www.codeforamerica.org/apps/ebtnearme/">Learn more</a></p>
+		        	</div>
+		    	</article>
+		    </li>
+			<li class="layout-crotchet">
+			    <article class="teaser teaser-app no-logo">
+			        <header class="teaser-header">
+			            <a href="http://www.codeforamerica.org/apps/promptly/">
+			                <h1 class="teaser-title">Promptly</h1>
+			            </a>
+			        </header>
+			        <div class="teaser-body">
+			            <p>Promptly text messages San Francisco Human Services Agency clients with important information to keep them enrolled in services.</p>
+			            <p><a href="http://www.codeforamerica.org/apps/promptly/">Learn more</a></p>
+			        </div>
+			    </article>
 			</li>
-		</ul>
-	</div>
-</section>
-<section>
-	<div class="slab-dark-blue">
-		<div class="layout-semibreve">
-			<div class="badge-heading badge-github badge-black" style="border-bottom:none">
-				<h4>Data Analyst, Designer or Developer? Get involved right away.</h4>
-				<p>We operate in the open. Our work benefits from contributions across the civic tech movement and the health and human services domain. Watch our proress, share your ideas, and get involved.</p>
-				<button href="https://github.com/codeforamerica/health">Visit us on Github</button>
-			</div>
-		</div>
-	</div>
-</section>
-<section id="people">
-	<div class="layout-semibreve">
-		<h2>Get in touch</h2>
-		<p>The Health focus area team includes designers, engineers, domain experts and fellows. <a href="/about/team">Learn about our entire team.</a> Get in touch to learn more about our work and how to deliver health and social services with dignity, by default.</p>
-		<figure>
-		    <blockquote>
-				<h5>Contact</h5>
-				<p><strong><a href="/people/rebecca-coelius/">Rebecca Coelius, Director of Health</strong></a></p>
-				<p><a href="mailto:rebeccac@codeforamerica.org">rebeccac@codeforamerica.org</a></p>
-		    </blockquote>
-		</figure>
+		    <li class="layout-crotchet">
+		        <article class="teaser teaser-app no-logo">
+		            <header class="teaser-header">
+		                <a href="http://www.codeforamerica.org/governments/longbeach/">
+		                    <h1 class="teaser-title">AddressIQ</h1>
+		                </a>
+		            </header>
+		            <div class="teaser-body">
+		                <p>In 2013, 52 percent of emergency medical calls in Long Beach, CA came from the same 10 percent of addresses. This dashboard analyzes data in order to identify these "super-utilizers" and help  find find ways to coordinate their care, reducing costs and improving outcomes.</p>
 
+		                <p><a href="http://www.codeforamerica.org/governments/longbeach/">Learn More</a></p>
+		            </div>
+		        </article>
+		    </li>
+		    <li class="layout-crotchet">
+		        <article class="teaser teaser-app no-logo">
+		            <header class="teaser-header">
+		                <a href="http://www.codeforamerica.org/our-work/data-formats/openreferral/">
+		                    <h1 class="teaser-title">Open Referral</h1>
+		                </a>
+		            </header>
+		            <div class="teaser-body">
+		                <p>People can't take advantage of services they don't know exist. Open Referral is an open data standard that makes it easier to find and share this information.</p>
+
+		                <p><a href="http://www.codeforamerica.org/our-work/data-formats/openreferral/">Learn More</a></p>
+		            </div>
+		        </article>
+		    </li>
+		</ul>
+		<p>
+			<br>
+		</p>
+	</div>
+</section>
+<section class="slab-dark-blue">
+	<div class="layout-semibreve">
+		<h2>Work with us</h2>
+		<div class="badge-heading badge-github badge-gov" style="border-bottom:none">
+			<h4>Get in touch to learn more.</h4>
+			<p>The Health focus area team includes designers, engineers, domain experts and fellows. <a href="/about/team">Learn about our entire team.</a> Get in touch to learn more about our work and how to deliver health and social services with dignity, by default.</p>
+			<h5>Contact</h5>
+			<p><strong><a href="/people/rebecca-coelius/">Rebecca Coelius, Director of Health</strong></a></p>
+			<p><a href="mailto:rebeccac@codeforamerica.org">rebeccac@codeforamerica.org</a></p>
+		</div>
+		<div class="badge-heading badge-github badge-black" style="border-bottom:none">
+			<h4>Data Analyst, Designer or Developer? Get involved right away.</h4>
+			<p>We operate in the open. Our work benefits from contributions across the civic tech movement and the health and human services domain. Watch our proress, share your ideas, and get involved.</p>
+			<button href="https://github.com/codeforamerica/health">Visit us on Github</button>
+		</div>
 	</div>
 </section>

--- a/our-work/focus-areas/health/index.html
+++ b/our-work/focus-areas/health/index.html
@@ -78,7 +78,7 @@ description: Code for America partners with local governments to build and grow 
 		</div>
 </section>
 <section class="slab-dark-blue">
-	<div class="layout-semibreve">
+	<div class="layout-semibreve layout-centered">
 		<h5>Our current partners</h5>
 		<nav class="list-credits" role="navigation">
 			<ul>
@@ -250,7 +250,7 @@ description: Code for America partners with local governments to build and grow 
 		<div class="badge-heading badge-github badge-gov" style="border-bottom:none">
 			<h4>Get in touch to learn more.</h4>
 			<p>The Health focus area team includes designers, engineers, domain experts and fellows. <a href="/about/team">Learn about our entire team.</a> Get in touch to learn more about our work and how to deliver health and social services with dignity, by default.</p>
-			<p>Contact <strong><a href="/people/rebecca-coelius/">Rebecca Coelius, Director of Health</strong></a> at <a href="mailto:rebeccac@codeforamerica.org">rebeccac@codeforamerica.org</a>.</p>
+			<p>Contact <strong><a href="/people/rebecca-coelius/">Rebecca Coelius, Director of Health</strong></a> at <a href="mailto:rebeccac@codeforamerica.org">rebeccac@codeforamerica.org</a></p>
 		</div>
 		<div class="badge-heading badge-github badge-black" style="border-bottom:none">
 			<h4>Data Analyst, Designer or Developer? Get involved right away.</h4>

--- a/our-work/focus-areas/health/index.html
+++ b/our-work/focus-areas/health/index.html
@@ -120,7 +120,7 @@ description: Code for America partners with local governments to build and grow 
 <section>
 	<div class="layout-semibreve">
 		<h4 class="heading">Original digital services produced with governments</h4>
-		<p><a href="/governments/fellowship/">The Code for America Fellowship Program</a> pairs teams of technologists for a year of deep partnership with a local government and the community  around a new or improved digital service. The output includes an “alpha” product for that digital service, an understanding of the problem space in one community informed by our Peer Network, a local government partner with greater capacity to demonstrate the Principles for 21st Century Government, and strong relationships across the service delivery team that can be leveraged in the future.</p>
+		<p><a href="/governments/fellowship/">The Code for America Fellowship Program</a> sends teams of technologists into local governments across the country to work full-time for a year in partnership with government officials and the community. The fellows apply 21st Century Government Principles to important problems, focused on health, economic development, and safety and justice. While the product of the Fellowship is typically an early stage application that improves the delivery of a government service, the process acts as a vehicle for driving cultural and structural change inside of government.</p>
 		<figure>
 		    <blockquote>
 		    	<p>We are currently recruiting city and county government partners for 2016 Fellowships! <a href="/governments/fellowship/">Learn more about applying.</a></p>

--- a/our-work/focus-areas/index.html
+++ b/our-work/focus-areas/index.html
@@ -20,7 +20,7 @@ nav-breadcrumbs:
 
 <section class="layout-semibreve">
    <div class="layout-centered">
-      <h2 class="h3">Starting in 2015, we are focusing our iterative, user-centered, and data-driven approach to government primarily in three areas: </br><a href="#health">health</a>, <a href="#economicdevelopment">economic development</a>, and <a href="#safety-and-justice">safety & justice</a>.<h2>
+      <h2 class="h3">Starting in 2015, we are focusing our iterative, user-centered, and data-driven approach to government primarily in three areas: </br><a href="/health">health</a>, <a href="#economicdevelopment">economic development</a>, and <a href="#safety-and-justice">safety & justice</a>.<h2>
    </div>	
 </section>
 <section class="layout-breve">
@@ -35,17 +35,12 @@ nav-breadcrumbs:
    </div>
    <div class="layout-minim">
       
-      <h3>Health and Dignity by Default</h3>
+      <h3><a href="/health">Health and Dignity by Default</a></h3>
       <p>Building technology that puts the user first can make it easier and more affordable to feed, shelter, and treat those in need.  Code for America partners with local governments, service organizations, and foundations to promote a culture of health by applying human centered design and modern technology to the delivery of services.</p>
-      <p><a href="mailto:rebeccac@codeforamerica.org?subject=Focus on Health">Get in touch</a></p>
-      <p>With the generous support of:</p>
-      <p>
-         <img src="../../media/images/focus-areas/chcf_logo.jpg">
-         <!-- <figcaption><strong>A Caption</strong>: Goes Here</figcaption> -->
-      </p>
-      
+      <p><a href="/health">Visit the Health focus area to learn more about our values, partners and partners.</a></p>
    </div>
    <div class= "layout-breve">
+    <h5 class="heading">Projects supporting health and human services</h4>
    <ul class="teasers">
 	<li class="layout-crotchet">
 	    <article class="teaser teaser-app no-logo">
@@ -120,11 +115,12 @@ nav-breadcrumbs:
 </div>
 </section>
 <div class="layout-breve">
+<h5 class="heading">Projects supporting safety and justice</h4>
   <ul class="teasers">
 	<li class="layout-crotchet">
 	    <article class="teaser teaser-app no-logo">
 	        <header class="teaser-header">
-	            <a href=""http://www.codeforamerica.org/governments/atlanta/">
+	            <a href="http://www.codeforamerica.org/governments/atlanta/">
 	                <h1 class="teaser-title">CourtBot</h1>
 	            </a>
 	        </header>
@@ -195,6 +191,7 @@ nav-breadcrumbs:
 </div>
 </section>
 <div class="layout-breve">
+<h5 class="heading">Projects supporting economic development</h4>
 <ul class="teasers">
 	<li class="layout-crotchet">
 	    <article class="teaser teaser-app no-logo">


### PR DESCRIPTION
- Updates to `our-work/focus-areas/health`
   - listed all health domain projects, in the `teaser-app no-logo` pattern which already was in use on the focus-area umbrella page.
   - Made some copywriting and layout adjustments as a result

- Updates to `our-work/focus-areas`
   - created links to the health focus area page in sensible places
   - removed mention of California Healthcare Foundation since they are now referenced with other major supporters on the health focus area page. 
   - Added a section heading for the project patterns, since it was wanting.