### PR TITLE
Remove email signup from global footer

### DIFF
--- a/_includes/global-footer.html
+++ b/_includes/global-footer.html
@@ -1,10 +1,4 @@
 <div class="global-footer" id="global-footer">
-  
-  <div class="slab-medium-red">
-    <div class="layout-breve layout-tight">
-      {% include email-signup-form.html context="footer" %}
-    </div><!-- end .layout-breve -->
-  </div><!-- end .slab-dark-blue -->
 
   <div class="layout-breve layout-tight">
   

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -86,7 +86,14 @@ nav-breadcrumbs:
       {% include nav.html %}
       <main role="main">
         {{ content }}
-        
+
+        <!-- Email signup form -->
+        <div class="slab-medium-red">
+          <div class="layout-breve layout-tight">
+            {% include email-signup-form.html context="footer" %}
+          </div><!-- end .layout-breve -->
+        </div><!-- end .slab-dark-blue -->
+
         {% include global-footer.html %}
       </main>
     </div>

--- a/_layouts/speakers.html
+++ b/_layouts/speakers.html
@@ -93,6 +93,13 @@ include-params: true
       <main role="main">
         {{ content }}
         
+        <!-- Email signup form -->
+        <div class="slab-medium-red">
+            <div class="layout-breve layout-tight">
+                {% include email-signup-form.html context="footer" %}
+            </div><!-- end .layout-breve -->
+        </div><!-- end .slab-dark-blue -->
+
         {% include global-footer.html %}
       </main>
     </div>

--- a/index.html
+++ b/index.html
@@ -184,6 +184,13 @@
 
 </section>
 
+<!-- Email signup form -->
+<div class="slab-medium-red">
+    <div class="layout-breve layout-tight">
+        {% include email-signup-form.html context="footer" %}
+    </div><!-- end .layout-breve -->
+</div><!-- end .slab-dark-blue -->
+
 {% include global-footer.html %}
 </main>
 </div>

--- a/stylesheets/staging.scss
+++ b/stylesheets/staging.scss
@@ -71,12 +71,12 @@ nav.nav-footer {
 
 /* Global Footer - main - signup form */
 
-.global-footer .signup-global {
+.signup-global {
 	margin: 32px 0;
 	color: white;
 }
 
-.global-footer .signup-global h4 {
+.signup-global h4 {
 	display: inline-block;
 	color: white;
 	margin-right: 16px;
@@ -84,12 +84,12 @@ nav.nav-footer {
 	margin-bottom: 20px;
 }
 
-.global-footer .signup-global h4 i:before {
+.signup-global h4 i:before {
 	margin-right: 10px;
 	font-size: 24px;
 }
 
-.global-footer .signup-global input[type="email"] {
+.signup-global input[type="email"] {
 	background-color: transparent;
 	color: white;
 	font-size: 14px;
@@ -108,23 +108,23 @@ nav.nav-footer {
 	@include placeholder-color(white);
 }
 
-.global-footer .signup-global input[type="email"]:focus {
+.signup-global input[type="email"]:focus {
 	border-color: white;
 	border-color: rgba(255, 255, 255, 0.5);
 }
 
-.global-footer .signup-global input[type="submit"] {
+.signup-global input[type="submit"] {
 	margin-bottom: 8px;
 }
 
 /* Global footer - layout (screens above 40em) */
 
 @media all and (min-width: 40em) {
-	.global-footer .signup-global {
+	.signup-global {
 		margin-left: 0;
 	}
 
-	.global-footer .signup-global input[type="email"] {
+	.signup-global input[type="email"] {
 		width: 300px;
 		margin-right: 8px;
 	}


### PR DESCRIPTION
We're serving up the global-footer to other sites. I'm removing the email signup from it for now to address some problems in #936. More updates needed in the future to make this a modular piece of code that can be dropped into sub-sites (like /blog/ and /brigade/).