### PR TITLE
Add new signup page and some patterns for that style of header, will need refactor later

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -181,6 +181,15 @@
   {% if page.description %}
   <div class="description layout-semibreve">
     <p class="page-description">{{ page.description }}</p>
+
+    {% if page.mailing-list-header %}
+      <form class="email-entry-form" action="//codeforamerica.us2.list-manage.com/subscribe/post?u=d9acf2a4c694efbd76a48936f&amp;id=3ac3aef1a5" method="post" target="_blank">
+        <span class="combined">
+          <input type="email" name="email" class="signup-email" placeholder="Enter your email address" style="width:50%" />
+          <input type="submit" value="Sign up" class="button-invert text-whisper white" />
+        </span>
+      </form>
+    {% endif %}
   </div>
   {% endif %}
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,12 +94,14 @@ nav-breadcrumbs:
       <main role="main">
         {{ content }}
 
+        {% unless page.mailing-list-header %}
         <!-- Email signup form -->
         <div class="slab-medium-red">
           <div class="layout-breve layout-tight">
             {% include email-signup-form.html context="footer" %}
           </div><!-- end .layout-breve -->
         </div><!-- end .slab-dark-blue -->
+        {% endunless %}
 
         {% include global-footer.html %}
       </main>

--- a/signup/index.html
+++ b/signup/index.html
@@ -15,5 +15,5 @@ title: Mailing list signup
 
 # Content for the custom deep masthead
 headline: Join Us.
-description: Join our e-mail list to learn how to use your skills to make your community better & we’ll send you info about Code for America’s work..
+description: Join our e-mail list to learn how to use your skills to make your community better & we’ll send you info about Code for America’s work.
 ---

--- a/signup/index.html
+++ b/signup/index.html
@@ -1,0 +1,19 @@
+---
+layout: default
+masthead-image: "/media/images/about/brigade.jpg"
+
+# Don't use the default masthead, use the custom deep masthead
+masthead: "no"
+nav-global-primary: "no"
+masthead-custom: deep
+
+# Hide the default mailing list, embed it below the description
+mailing-list-header: true
+
+# Title for the title bar, and the overline in the masthead
+title: Mailing list signup
+
+# Content for the custom deep masthead
+headline: Join Us.
+description: Join thousands who are committed to making government work for the people, by the people.
+---

--- a/signup/index.html
+++ b/signup/index.html
@@ -15,5 +15,5 @@ title: Mailing list signup
 
 # Content for the custom deep masthead
 headline: Join Us.
-description: Join thousands who are committed to making government work for the people, by the people.
+description: Join our e-mail list to learn how to use your skills to make your community better & we’ll send you info about Code for America’s work..
 ---


### PR DESCRIPTION
First step to making this a real thing. When CfA people are out and about, they can send people to http://codeforamerica.org/signup to sign up directly for our mailing list.

Link to preview: http://jekit.codeforamerica.org/codeforamerica/codeforamerica.org/email-signup-page/signup/index.html

cc @Jaime-Alexis @ZoeBlumenfeld for review. 
cc @pahlkadot, who requested.