### PR TITLE
Add team name tags to 2015 fellow bios/cards

### DIFF
--- a/_includes/people/alex-soble.html
+++ b/_includes/people/alex-soble.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/somerville/">Somerville Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -49,7 +49,7 @@
     <h3 class="p-name profile-name">Alex Soble</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/alex-soble.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/somerville/">Somerville Team</a></p>
 
         <p> Alex is a starter and a coder. He loves technology that contributes to the public good and has built web products for both government and startups...
 </p>

--- a/_includes/people/amir-hadjihabib.html
+++ b/_includes/people/amir-hadjihabib.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/somerville/">Somerville Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -48,7 +48,7 @@
     <h3 class="p-name profile-name">Amir Hadjihabib</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/amir-hadjihabib.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/somerville/">Somerville Team</a></p>
 
         <p> Amir is a San Francisco based Product Designer and avid photographer. At Zendesk, he was part of the team that created the acclaimed Link-SF app...
 </p>

--- a/_includes/people/andrew-schneider.html
+++ b/_includes/people/andrew-schneider.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/vallejo/">Vallejo Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -49,7 +49,7 @@
     <h3 class="p-name profile-name">Andrew Schneider</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/andrew-schneider.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/vallejo/">Vallejo Team</a></p>
 
         <p>Andrew is a full stack developer from Seattle who likes working on data visualization and geospatial problems. Before making the leap to software...
 </p>

--- a/_includes/people/ben-golder.html
+++ b/_includes/people/ben-golder.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/rva-community-partners/">RVA Community Partners Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -48,7 +48,7 @@
     <h3 class="p-name profile-name">Ben Golder</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/ben-golder.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/rva-community-partners/">RVA Community Partners Team</a></p>
 
         <p> Ben designs information, maps, and civic technology. He studied urban planning at MIT and architecture at UC Berkeley and has instructed designers...
 </p>

--- a/_includes/people/ben-smithgall.html
+++ b/_includes/people/ben-smithgall.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/pittsburgh/">Pittsburgh Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -48,7 +48,7 @@
     <h3 class="p-name profile-name">Ben Smithgall</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/ben-smithgall.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/pittsburgh/">Pittsburgh Team</a></p>
 
         <p>Ben is a developer originally from Pittsburgh. After graduating from the University of Chicago with a degree in Public Policy, Ben worked on the digital and data teams...
 </p>

--- a/_includes/people/chris-reade.html
+++ b/_includes/people/chris-reade.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/indianapolis/">Indianapolis Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -46,7 +46,7 @@
     <h3 class="p-name profile-name">Chris Reade</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/chris-reade.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/indianapolis/">Indianapolis Team</a></p>
 
         <p>  Chris is a software developer originally from Metro Detroit. Over the past four years he has worked in software delivery and process consulting...
 </p>

--- a/_includes/people/emma-smithayer.html
+++ b/_includes/people/emma-smithayer.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/rva-community-partners/">RVA Community Partners Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -49,7 +49,7 @@
     <h3 class="p-name profile-name">Emma Smithayer</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/emma-smithayer.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/rva-community-partners/">RVA Community Partners Team</a></p>
 
         <p> Emma is a software developer from Burlington, Vermont. Prior to joining Code for America, she worked on electronic medical records at athenahealth...
 </p>

--- a/_includes/people/ernie-hsiung.html
+++ b/_includes/people/ernie-hsiung.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/miami-dade/">Miami-Dade County Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -45,7 +45,7 @@
     <h3 class="p-name profile-name">Ernie Hsiung</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/ernie-hsiung.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/miami-dade/">Miami-Dade County Team</a></p>
 
         <p> Ernie is a front-end developer and a community organizer with an interest in both actual and virtual communities. Born and raised in the Bay Area and living in Miami...
 </p>

--- a/_includes/people/grant-smith.html
+++ b/_includes/people/grant-smith.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/westsacramento/">West Sacramento Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -43,7 +43,7 @@
     <h3 class="p-name profile-name">Grant Smith</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/grant-smith.png">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/westsacramento/">West Sacramento Team</a></p>
 
         <p> Grant is a software developer from Madison, Wisconsin. After earning a degree in biomedical engineering, he developed a love for programming while working...
 </p>

--- a/_includes/people/imanol-aranzadi.html
+++ b/_includes/people/imanol-aranzadi.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/westsacramento/">West Sacramento Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -44,7 +44,7 @@
     <h3 class="p-name profile-name">Imanol Aranzadi</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/imanol-aranzadi.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/westsacramento/">West Sacramento Team</a></p>
 
         <p>   Imanol Aranzadi is a front-end designer and developer from Caguas, Puerto Rico. A former practicing psychologist, Imanol loves mixing social sciences...
 </p>

--- a/_includes/people/jazmyn-latimer.html
+++ b/_includes/people/jazmyn-latimer.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/vallejo/">Vallejo Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -49,7 +49,7 @@
     <h3 class="p-name profile-name">Jazmyn Latimer</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/jazmyn-latimer.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/vallejo/">Vallejo Team</a></p>
 
         <p>Jazmyn, a researcher and user experience designer, is interested in combining social science to solve problems and enhance lives through technology...
 </p>

--- a/_includes/people/jennings-hanna.html
+++ b/_includes/people/jennings-hanna.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/albuquerque/">Albuquerque Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -43,7 +43,7 @@
     <h3 class="p-name profile-name">Jennings Hanna</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/jennings-hanna.png">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/albuquerque/">Albuquerque Team</a></p>
 
         <p> Jennings Hanna believes that together we can make the world stronger through design. Prior to the CfA he’s been designing content and interactions for the NFL....
 </p>

--- a/_includes/people/laura-ellena.html
+++ b/_includes/people/laura-ellena.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/indianapolis/">Indianapolis Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -42,7 +42,7 @@
     <h3 class="p-name profile-name">Laura Ellena</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/laura-ellena.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/indianapolis/">Indianapolis Team</a></p>
 
         <p> Laura is a user researcher who's interested in using technology to help people reach their goals. Most recently, she helped combine UX and Market Research to enable ModCloth...
 </p>

--- a/_includes/people/mari-muraki.html
+++ b/_includes/people/mari-muraki.html
@@ -3,11 +3,11 @@
 <div class="layout-semibreve h-card">
 
 	<div class="heading">
-		<h2 class="p-name">Mari Muraki </h2>
+		<h2 class="p-name">Mari Muraki</h2>
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/somerville/">Somerville Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -48,7 +48,7 @@
     <h3 class="p-name profile-name">Mari Muraki</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/mari-muraki.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/somerville/">Somerville Team</a></p>
 
         <p> Mari is a data lover and researcher hailing from New Jersey and moving west over the years: studying mathematics and statistics at the University of Chicago...
 </p>

--- a/_includes/people/mathias-gibson.html
+++ b/_includes/people/mathias-gibson.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/miami-dade/">Miami-Dade County Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -47,7 +47,7 @@
     <h3 class="p-name profile-name">Mathias Gibson</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/mathias-gibson.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/miami-dade/">Miami-Dade County Team</a></p>
 
         <p>  Mathias is a public policy researcher passionate about social justice, urban citizenship and community. Most recently, he worked for the City of San Francisco's 311 office...
 </p>

--- a/_includes/people/natasha-fountain.html
+++ b/_includes/people/natasha-fountain.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/westsacramento/">West Sacramento Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -47,7 +47,7 @@
     <h3 class="p-name profile-name">Natasha Fountain</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/natasha-fountain.png">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/westsacramento/">West Sacramento Team</a></p>
 
         <p> Natasha is a designer from Fort Lauderdale, Florida. She’s led the design of enterprise-level SaaS products, created typefaces, Tumblr themes...
 </p>

--- a/_includes/people/nikki-zeichner.html
+++ b/_includes/people/nikki-zeichner.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/vallejo/">Vallejo Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -44,7 +44,7 @@
     <h3 class="p-name profile-name">Nikki Zeichner</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/nikki-zeichner.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/vallejo/">Vallejo Team</a></p>
 
         <p>  Nikki is a lawyer and a recent graduate of NYU Engineering School's Integrated Digital Media program. Before studying technology and design, Nikki worked as a criminal defense attorney...
 </p>

--- a/_includes/people/patrick-hammons.html
+++ b/_includes/people/patrick-hammons.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/pittsburgh/">Pittsburgh Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -48,7 +48,7 @@
     <h3 class="p-name profile-name">Patrick Hammons</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/patrick-hammons.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/pittsburgh/">Pittsburgh Team</a></p>
 
         <p>Patrick is a map nerd and civic hacker passionate about making data more accessible both visually and through online applications...
 </p>

--- a/_includes/people/sam-matthews.html
+++ b/_includes/people/sam-matthews.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/rva-community-partners/">RVA Community Partners Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -49,7 +49,7 @@
     <h3 class="p-name profile-name">Sam Matthews</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/sam-matthews.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/rva-community-partners/">RVA Community Partners Team</a></p>
 
         <p>Sam is a front-end web developer, designer, and cartographer. He helped create Situated Laboratories, a firm devoted to helping people explore and showcase their digital brand...
 </p>

--- a/_includes/people/shelly-ni.html
+++ b/_includes/people/shelly-ni.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/pittsburgh/">Pittsburgh Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -44,7 +44,7 @@
     <h3 class="p-name profile-name">Shelly Ni</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/shelly-ni.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/pittsburgh/">Pittsburgh Team</a></p>
 
         <p> Shelly is an interaction designer &mdash; someone who solves problems that happen over time. As a co-founder of Propel, she designed a food stamp application that works on any smartphone. For her MFA thesis, she created...
 </p>

--- a/_includes/people/sophia-dengo.html
+++ b/_includes/people/sophia-dengo.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/miami-dade/">Miami-Dade County Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -46,7 +46,7 @@
     <h3 class="p-name profile-name">Sophia Dengo</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/sophia-dengo.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/miami-dade/">Miami-Dade County Team</a></p>
 
         <p>  Sophia is a web developer and designer based in San Francisco, California. After spending a few years creating interactive interfaces for CNN.com in Atlanta...
 </p>

--- a/_includes/people/tiffany-andrews.html
+++ b/_includes/people/tiffany-andrews.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+		<p><a href="{{ include.base }}/governments/indianapolis/">Indianapolis Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -42,7 +42,7 @@
     <h3 class="p-name profile-name">Tiffany Andrews</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/tiffany-andrews.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/indianapolis/">Indianapolis Team</a></p>
 
         <p> Tiffany has 10 years of experience in politics and government administration and is a budding junior front-end developer....
 </p>

--- a/_includes/people/william-tyner.html
+++ b/_includes/people/william-tyner.html
@@ -7,7 +7,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/albuquerque/">Albuquerque Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -43,7 +43,7 @@
     <h3 class="p-name profile-name">William Tyner</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/william-tyner.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/albuquerque/">Albuquerque Team</a></p>
 
         <p>  William is an anthropologist and designer. Recently, William worked for General Assembly where he led projects to increase diversity in the tech industry....
 </p>

--- a/_includes/people/yaniv-zimet.html
+++ b/_includes/people/yaniv-zimet.html
@@ -8,7 +8,7 @@
 	</div>
 
 	<div class="layout-minor">
-		<p>2015 Fellow</p>
+  		<p><a href="{{ include.base }}/governments/albuquerque/">Albuquerque Team</a></p>
 	    <h4 class="text-whisper layout-tight">Member of</h4>
 	    <ul class="list-no-bullets text-whisper link-invert">
 	    	<li><a href="{{ include.base }}/geeks/our-geeks/2015-fellows/">2015 Fellow</a></li>
@@ -44,7 +44,7 @@ Yaniv is a software engineer specializing in front-end interactive web developme
     <h3 class="p-name profile-name">Yaniv Zimet</h3><img class="u-photo profile-photo" src="{{ include.base }}/media/images/people/yaniv-zimet.jpg">
 
     <div class="p-note profile-note">
-        <p>2015 Fellow</p>
+        <p><a href="{{ include.base }}/governments/albuquerque/">Albuquerque Team</a></p>
 
         <p>  Yaniv is a software engineer specializing in front-end interactive web development. Most recently, Yaniv worked at Weather Underground building....
 </p>


### PR DESCRIPTION
Each fellow now has a team name with a link back to their city. Fixes #919.