### PR TITLE
tweak copy for jobs button

### DIFF
--- a/about/team/index.html
+++ b/about/team/index.html
@@ -18,7 +18,7 @@ nav-breadcrumbs:
 
   <ul class="list-inline list-no-bullets">
     <li><a href="/about/board" class="button">Meet the Board</a></li>
-    <li><a href="/jobs" class="button">See Open Positions</a></li>
+    <li><a href="/jobs" class="button">Job Opportunities</a></li>
   </ul>
 </section>
 


### PR DESCRIPTION
we don’t appear to use the phrase “open positions” on the job page, so
a tweak to change the button copy to “Job Opportunities”