### PR TITLE
When building on Travis, specify ruby 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+rvm: 
+- 2.2.0
 before_install:
 - travis_retry gem install jekyll --no-ri --no-rdoc
 - sudo apt-get update -y


### PR DESCRIPTION
Attempted quick fix to solve our breaking build on Travis (see https://travis-ci.org/codeforamerica/codeforamerica.org/builds/57733171) by specifying ruby 2.2.0 before installing jekyll.

Long term, it seems like we might want to introduce bundler and specify which ruby we want to use in a Gemfile. Then we can run jekyll with `bundle exec jekyll <blah>` locally, during testing and on production and keep a consistent environment.

(ping @migurski ^ thoughts on that longterm?)