### PR TITLE
Removed reference to PostCode to reflect their new strategy

### DIFF
--- a/_includes/apps/cityvoice.html
+++ b/_includes/apps/cityvoice.html
@@ -36,7 +36,7 @@
 	    		<tr><th>Video</th><td><a href="http://www.youtube.com/watch?v=FV16zvHJcRY">http://www<wbr>.youtube<wbr>.com/<wbr>watch?v=<wbr>FV16zvHJcRY</a></td></tr>
 	    		<tr><th>Codebase</th><td><a href="https://github.com/codeforamerica/cityvoice">https://github<wbr>.com/<wbr>codeforamerica/<wbr>cityvoice</a></td></tr>
 	    		<tr><th>Environment</th><td>Ruby on Rails with Twilio for telephone integration.</td></tr>
-	    		<tr><th>Redeploy</th><td>Contact <a href="http://postcode.io">Postcode.io</a> or follow Heroku <a href="https://github.com/codeforamerica/cityvoice#setup-internal-documentation">installation instructions on Github</a>.</td></tr>
+	    		<tr><th>Redeploy</th><td>Follow Heroku <a href="https://github.com/codeforamerica/cityvoice#setup-internal-documentation">installation instructions on Github</a>.</td></tr>
 	    	</table>
 	    	<a href="https://codeforamerica.wufoo.com/forms/app-inquiry-form/" class="button-alternative">Contact us to deploy this app</a>
 	    </div>
@@ -64,7 +64,7 @@
             <p>Ruby on Rails with Twilio for telephone integration.</p>
             
             <h2 class="text-whisper">Redeploy</h2>
-            <p>Contact <a href="http://postcode.io">Postcode.io</a> or follow Heroku <a href="https://github.com/codeforamerica/cityvoice#setup-internal-documentation">installation instructions on Github</a>.</p>
+            <p>Follow Heroku <a href="https://github.com/codeforamerica/cityvoice#setup-internal-documentation">installation instructions on Github</a>.</p>
             
             <p><a href="{{ include.base }}/apps/cityvoice">Learn more about this app</a></p>
         </div>

--- a/_includes/apps/promptly.html
+++ b/_includes/apps/promptly.html
@@ -38,7 +38,7 @@
 	    		<tr><th>Video</th><td><a href="http://www.youtube.com/watch?v=vnJIzYBdcVI">http://www<wbr>.youtube<wbr>.com/<wbr>watch?v=vnJIzYBdcVI</a></td></tr>
 	    		<tr><th>Codebase</th><td><a href="https://github.com/codeforamerica/promptly">https://github<wbr>.com/<wbr>codeforamerica/<wbr>promptly</a></td></tr>
 	    		<tr><th>Environment</th><td></td></tr>
-	    			    		<tr><th>Redeploy</th><td>Contact <a href="http://postcode.io">Postcode.io</a> or follow Heroku <a href="https://github.com/codeforamerica/promptly#install-locally">installation instructions on Github</a>.</td></tr>	    	</table>
+	    			    		<tr><th>Redeploy</th><td>Follow Heroku <a href="https://github.com/codeforamerica/promptly#install-locally">installation instructions on Github</a>.</td></tr>	    	</table>
 	    			    			    </div>
 	    
         <p>Many CalFresh (Food Stamps) recipients in San Francisco &nbsp;discover that they’ve been disenrolled from benefits while trying to pay for their groceries. It’s a stressful and embarrassing moment. What’s worse, some of these same people have to reapply for services from scratch.&nbsp;Promptly stops this from happening by sending a text message to recipients before they’re disenrolled.</p>
@@ -62,7 +62,7 @@
             <p></p>
         
             <h2 class="text-whisper">Redeploy</h2>
-            <p>Contact <a href="http://postcode.io">Postcode.io</a> or follow Heroku <a href="https://github.com/codeforamerica/promptly#install-locally">installation instructions on Github</a>.</p>
+            <p>Follow Heroku <a href="https://github.com/codeforamerica/promptly#install-locally">installation instructions on Github</a>.</p>
         
             <p><a href="{{ include.base }}/apps/promptly">Learn more about this app</a></p>
         </div>

--- a/_includes/apps/recordtrac.html
+++ b/_includes/apps/recordtrac.html
@@ -7,7 +7,7 @@
 	<div class="layout-minor">
 		<img class="isolate" src="{{ include.base }}/media/images/apps/RecordTrac_header.jpg" />
 	    <h3 class="text-prominent">Overview</h3>
-	    <p>RecordTrac makes public records requests friendlier for the public and easier for governments to manage. The application is delivered by PostCode.io, a full service civic technology company.</p>
+	    <p>RecordTrac makes public records requests friendlier for the public and easier for governments to manage.</p>
 	    
 	    <p class="text-whisper"><a href="http://records.oaklandnet.com">http://records<wbr>.oaklandnet<wbr>.com</a></p>
 	    


### PR DESCRIPTION
It’s our understanding that PostCode is no longer delivering CityVoice, Promptly, or RecordTrac.