### PR TITLE
Fix community-url in frontmatter

### DIFF
--- a/our-work/initiatives/digitalfrontdoor/playbook/user-needs/goals-good-city-website.md
+++ b/our-work/initiatives/digitalfrontdoor/playbook/user-needs/goals-good-city-website.md
@@ -5,7 +5,7 @@ subtitle: The principles and goals city websites should aim to achieve
 nav-breadcrumbs:
   - "Digital Front Door": "/our-work/initiatives/digitalfrontdoor/"
   - "User Needs": "/our-work/initiatives/digitalfrontdoor/playbook/user-needs/"
- community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
+community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
 community-cta:	"Join the conversation and talk to other local government staff in our Digital Front Door community."
 
 ---

--- a/our-work/initiatives/digitalfrontdoor/playbook/user-needs/run-a-resident-survey.md
+++ b/our-work/initiatives/digitalfrontdoor/playbook/user-needs/run-a-resident-survey.md
@@ -5,7 +5,7 @@ subtitle: Learn how to conduct a baseline survey of your residents before you st
 nav-breadcrumbs:
   - "Digital Front Door": "/our-work/initiatives/digitalfrontdoor/"
   - "User Needs": "/our-work/initiatives/digitalfrontdoor/playbook/user-needs/"
-  community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
+community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
 community-cta:	"Join the conversation and talk to other local government staff in our Digital Front Door community."
 ---
 

--- a/our-work/initiatives/digitalfrontdoor/playbook/user-needs/what-should-city-website-do.md
+++ b/our-work/initiatives/digitalfrontdoor/playbook/user-needs/what-should-city-website-do.md
@@ -5,7 +5,7 @@ subtitle: Principles and goals for city websites
 nav-breadcrumbs:
   - "Digital Front Door": "/our-work/initiatives/digitalfrontdoor/"
   - "User Needs": "/our-work/initiatives/digitalfrontdoor/playbook/user-needs/"
-  community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
+community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
 community-cta:	"Join the conversation and talk to other local government staff in our Digital Front Door community."
 
 ---

--- a/our-work/initiatives/digitalfrontdoor/playbook/user-needs/where-do-i-start.md
+++ b/our-work/initiatives/digitalfrontdoor/playbook/user-needs/where-do-i-start.md
@@ -5,7 +5,7 @@ subtitle: Learn how to start a redesign of your city website
 nav-breadcrumbs:
   - "Digital Front Door": "/our-work/initiatives/digitalfrontdoor/"
   - "User Needs": "/our-work/initiatives/digitalfrontdoor/playbook/user-needs/"
-  community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
+community-url:	"https://groups.google.com/a/codeforamerica.org/forum/#!forum/digital-front-door"
 community-cta:	"Join the conversation and talk to other local government staff in our Digital Front Door community."
 ---
 


### PR DESCRIPTION
The space before the community-url is preventing Jekyll from compiling [these](http://www.codeforamerica.org/our-work/initiatives/digitalfrontdoor/playbook/user-needs/goals-good-city-website.html) [pages](http://www.codeforamerica.org/our-work/initiatives/digitalfrontdoor/playbook/user-needs/where-do-i-start.html) correctly.