### PR TITLE
Reinstate redirects for /apply

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -208,8 +208,8 @@ RedirectMatch permanent ^/geeks/fellowship/?$ /about/fellowship
 RedirectMatch permanent ^/governments/city-impact/?$ /about/fellowship
 RedirectMatch permanent ^/fellows(/?)$ /about/fellowship$1
 RedirectMatch permanent ^/the-program/?$ /about/fellowship
-#RedirectMatch permanent ^/apply/?$ https://screendoor.dobt.co/code-for-america/2015-fellowship-application
-#RedirectMatch permanent ^/Apply/?$ https://screendoor.dobt.co/code-for-america/2015-fellowship-application
+RedirectMatch permanent ^/apply/?$ /geeks/fellowship-apply
+RedirectMatch permanent ^/Apply/?$ /geeks/fellowship-apply
 
 #
 # Another round of Fellowship Program reorganization

--- a/.test-httpd.py
+++ b/.test-httpd.py
@@ -198,6 +198,8 @@ class TestApache (unittest.TestCase):
                  ('/health', '/our-work/focus-areas/health/'),
                  ('/safety-justice', '/our-work/focus-areas/safety-justice/'),
                  ('/economic-development', '/our-work/focus-areas/economic-development/'),
+                 ('/apply', '/geeks/fellowship-apply/'),
+                 ('/Apply', '/geeks/fellowship-apply/'),
                  
                  # # This actually goes to BSD, but we check for it anyway.
                  # ('/donate', '/page/contribute/default'),


### PR DESCRIPTION
codeforamerica.org/apply will redirect to the fellowship-apply page.