### PR TITLE
Add numbers to sponsor page

### DIFF
--- a/summit/sponsor/index.html
+++ b/summit/sponsor/index.html
@@ -35,6 +35,16 @@ metadata:
     font-size: 14px;
     line-height: 2;
   }
+  
+  /* Number component */
+  .number {
+    /* To match badge-heading */
+    padding-top: 32px;
+  }
+  .number__value {
+    font-size: 32px;
+    font-weight: bold;
+  }
 </style>
 
 <section class="layout-semibreve">
@@ -57,19 +67,37 @@ metadata:
 
 <section class="slab-gray">
   <div class="layout-semibreve">
-    <h2 id="announcement" class="layout-centered">Benefits</h2>
-    <div class="badge-heading badge-glasses" style="border-bottom:none;">
-      <h4>Breakout Sessions</h4>
-      <p>Captivate the audience with a breakout session on the topic of your choice.</p>
+    <div class="layout-minim">
+      <h2 id="announcement" class="layout-centered">Benefits</h2>
+      <div class="badge-heading badge-glasses" style="border-bottom:none;">
+        <h4>Breakout Sessions</h4>
+        <p>Captivate the audience with a breakout session on the topic of your choice.</p>
+      </div>
+      <div class="badge-heading badge-graph" style="border-bottom:none;">
+        <h4>Tech Fair</h4>
+        <p>Converse with government staff, developers and designers at this year's two-day Tech Fair.</p>
+      </div>
+      <div class="badge-heading" style="border-bottom:none;">
+        <h4>Branding</h4>
+        <p>Position yourself as a leader of innovative government tools and platforms.</p>
+      </div><!-- end .layout-semibreve -->
     </div>
-    <div class="badge-heading badge-graph" style="border-bottom:none;">
-      <h4>Tech Fair</h4>
-      <p>Converse with government staff, developers and designers at this year's two-day Tech Fair.</p>
+    <div class="layout-minim">
+      <h2 class="layout-centered">Breakdown</h2>
+      <div class="number">
+        <h4 class="number__value">826</h4>
+        <p class="number__description">Attendees at the 2014 Summit &mdash; we're expecting an even larger audience in 2015</p>
+      </div>
+      <div class="number">
+        <h4 class="number__value">64%</h4>
+        <p class="number__description">Increase in Summit attendees from 2013 to 2014</p>
+      </div>
+      <div class="number">
+        <h4 class="number__value">17,000</h4>
+        <p class="number__description">Technologists, governments, staff and entreprenuers engaging with our email list</p>
+      </div>
+      <p><a href="http://c4a.me/2015summitprospectus">(Read more by-the-numbers breakdowns in our Prospectus.)</a></p>
     </div>
-    <div class="badge-heading" style="border-bottom:none;">
-      <h4>Branding</h4>
-      <p>Position yourself as a leader of innovative government tools and platforms.</p>
-    </div><!-- end .layout-semibreve -->
   </div>
 </section>
 

--- a/summit/sponsor/index.html
+++ b/summit/sponsor/index.html
@@ -56,58 +56,57 @@ metadata:
 </section>
 
 <section class="slab-gray">
-<div class="layout-semibreve">
-<h2 id="announcement" align="center">Benefits</h2><br>
-<div class="badge-heading badge-glasses" style="border-bottom:none">
+  <div class="layout-semibreve">
+    <h2 id="announcement" class="layout-centered">Benefits</h2>
+    <div class="badge-heading badge-glasses" style="border-bottom:none;">
       <h4>Breakout Sessions</h4>
-    <p>Captivate the audience with a breakout session on the topic of your choice.</p>
+      <p>Captivate the audience with a breakout session on the topic of your choice.</p>
     </div>
-  <div class="badge-heading badge-graph" style="border-bottom:none">
+    <div class="badge-heading badge-graph" style="border-bottom:none;">
       <h4>Tech Fair</h4>
-    <p>Converse with government staff, developers and designers at this year's two-day Tech Fair.</p>
+      <p>Converse with government staff, developers and designers at this year's two-day Tech Fair.</p>
     </div>
-    <div class="badge-heading" style="border-bottom:none">
+    <div class="badge-heading" style="border-bottom:none;">
       <h4>Branding</h4>
       <p>Position yourself as a leader of innovative government tools and platforms.</p>
-    </div>
-    </div>
-</section>
-<section class="slab-medium-red" style="padding-top:3em; padding-bottom:3em">
-  <h2 align="center">Become a sponsor</h2><br>
-  <div class="button-group" align="center">
-    <a href="http://c4a.me/2015summitprospectus" class="button button-lg">Check out the prospectus</a>
-    <a href="mailto:sponsorships@codeforamerica.org" class="button button-lg">Contact our Sponsorships Team</a>
+    </div><!-- end .layout-semibreve -->
   </div>
 </section>
 
-<section class= "slab-gray">
-  <div class= "layout-semibreve">
-  <h2>Scenes from the 2014 Summit</h2>
-  <br>
-  <div class="layout-grid-minim">
-    <div>
-      <img src="/media/images/summit/2015/sponsor/networking.jpg" alt="">
-      <p><strong>Connect with our technologists</strong></p>
-      <p>Code for Puerto Rico Brigade leader Imanol Aranzadi chats with other Brigade Captains about community organizing.</p>
+<section class="slab-medium-red">
+  <div class="layout-semibreve layout-centered">
+    <h2>Become a sponsor</h2><br>
+    <div class="button-group">
+      <a href="http://c4a.me/2015summitprospectus" class="button button-lg">Check out the prospectus</a>
+      <a href="mailto:sponsorships@codeforamerica.org" class="button button-lg">Contact our Sponsorships Team</a>
     </div>
+  </div>
+</section>
 
-    <div>
-      <img src="/media/images/summit/2015/sponsor/breakoutphoto.jpg" alt="">
-      <p><strong>Showcase your work</strong></p>
-    <p>2014 CfA Fellow Molly McLeod leads a breakout session on designing better health information.</p>
-    </div>
-    
-    <div>
-      <img src="/media/images/summit/2015/sponsor/mainstage.jpg" alt="">
-      <p><strong>Brush up on the latest trends</strong></p>
-    <p>The Atlanta Fellowship team features its CourtBot application, which allows Atlanta residents to pay their parking ticket via text, rather than waiting for hours in line.</p>
-    </div>
-    
-    <div>
-      <img src="/media/images/summit/2015/sponsor/techfair.jpg" alt="">
-      <p><strong>Represent at the Tech Fair</strong></p>
-      <p>OpenCounter, an economic development civic startup, engages with eager Summit attendees.</p>
-    </div>
+<section class="slab-gray">
+  <div class="layout-semibreve">
+    <h2 class="layout-centered">Scenes from the 2014 Summit</h2><br />
+    <div class="layout-grid-minim">
+      <div>
+        <img src="/media/images/summit/2015/sponsor/networking.jpg" alt="">
+        <p><strong>Connect with our technologists</strong></p>
+        <p>Code for Puerto Rico Brigade leader Imanol Aranzadi chats with other Brigade Captains about community organizing.</p>
+      </div>
+      <div>
+        <img src="/media/images/summit/2015/sponsor/breakoutphoto.jpg" alt="">
+        <p><strong>Showcase your work</strong></p>
+        <p>2014 CfA Fellow Molly McLeod leads a breakout session on designing better health information.</p>
+      </div>
+      <div>
+        <img src="/media/images/summit/2015/sponsor/mainstage.jpg" alt="">
+        <p><strong>Brush up on the latest trends</strong></p>
+        <p>The Atlanta Fellowship team features its CourtBot application, which allows Atlanta residents to pay their parking ticket via text, rather than waiting for hours in line.</p>
+      </div>
+      <div>
+        <img src="/media/images/summit/2015/sponsor/techfair.jpg" alt="">
+        <p><strong>Represent at the Tech Fair</strong></p>
+        <p>OpenCounter, an economic development civic startup, engages with eager Summit attendees.</p>
+      </div>
     </div><!-- end .layout-grid-minim -->
-    </div>
+  </div>
 </section>

--- a/summit/sponsor/index.html
+++ b/summit/sponsor/index.html
@@ -37,25 +37,24 @@ metadata:
   }
 </style>
 
-<section class= "layout-semibreve">
+<section class="layout-semibreve">
   <h2 id="announcement" align="center">Testimonials</h2><br>
-  <ul class="profiles layout-grid-minim" align="center">
-
+  <ul class="profiles layout-grid-minim layout-centered">
     <li>
-        <h3>Google</h3>
-        <img src="/media/images/summit/2015/sponsor/jonathan-betz.jpg" />
-        <h4><p>It's the best place to connect with the civic innovation community, discover new ideas, and get inspired.</h4><br>
-          <h5>Jonathan Betz, <em>Engineering Manager</em></h5>
-        </p>
+      <h3>Google</h3>
+      <img src="/media/images/summit/2015/sponsor/jonathan-betz.jpg" />
+      <h4>It's the best place to connect with the civic innovation community, discover new ideas, and get inspired.</h4>
+      <h5><br />Jonathan Betz, <em>Engineering Manager</em></h5>
     </li>
     <li>
-        <h3>Accela</h3>
-        <img src="/../media/images/people/kris-trujillo.jpg" />
-        <h4><p>Excited to be at the #cfasummit. One of the best conferences of the year!</h4><br>
-          <h5>Kris Trujillo, <em>VP of Products</em></h5>
-        </p>
+      <h3>Accela</h3>
+      <img src="/../media/images/people/kris-trujillo.jpg" />
+      <h4>Excited to be at the #cfasummit. One of the best conferences of the year!</h4>
+      <h5><br />Kris Trujillo, <em>VP of Products</em></h5>
     </li>
+  </ul>
 </section>
+
 <section class="slab-gray">
 <div class="layout-semibreve">
 <h2 id="announcement" align="center">Benefits</h2><br>


### PR DESCRIPTION
Adds some pull-out numbers to the sponsor page to give potential sponsors an idea of the scale of the event.

@Jaime-Alexis could you review and let me know if these are the right numbers / if we should add more numbers?