### PR TITLE
Removing stray table row

### DIFF
--- a/_includes/apps/cityvoice.html
+++ b/_includes/apps/cityvoice.html
@@ -23,7 +23,6 @@
 
 	    <div class="spotlight">
 	    	<table class="table-unstyled table-minor">
-	    		<tr><th>Create Trial</th><td>/td></tr>
 	    		<tr><th>Live Example</th><td><a href="http://www.southbendvoices.com/">http://www<wbr>.southbendvoices<wbr>.com/</a></td></tr>
 	    		<tr><th>Video</th><td><a href="http://www.youtube.com/watch?v=FV16zvHJcRY">http://www<wbr>.youtube<wbr>.com/<wbr>watch?v=<wbr>FV16zvHJcRY</a></td></tr>
 	    		<tr><th>Codebase</th><td><a href="https://github.com/codeforamerica/cityvoice">https://github<wbr>.com/<wbr>codeforamerica/<wbr>cityvoice</a></td></tr>


### PR DESCRIPTION
The row currently contains a broken /td> tag, so it needs improvement.

Outright removal matches the style of e.g. adopt-a-hydrant page.  The CTA at the bottom of the table has the trial information.