### PR TITLE
Add /awards/ redirect to awards.cfa.org

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -341,6 +341,7 @@ RedirectMatch permanent ^/focus/?$ /our-work/focus-areas
 RedirectMatch permanent ^/(FluShotFinder|flu-shot-finder|flushotfinder)$ /apps/flu-shot-finder/
 RedirectMatch permanent ^/projects/new-york-city-hhc-accelerator/?$ /projects/new-york-city-hhs-accelerator/
 RedirectMatch permanent ^/talent/?$ /our-work/initiatives/talent/
+RedirectMatch permanent ^/awards/?$ http://awards.codeforamerica.org$1
 
 #
 # Set of possible Jekyll file extensions + PHP, from


### PR DESCRIPTION
The awards site is on a subdomain (it's built separately from our main site). Let's redirect /awards/ just in-case someone tries to find it without a subdomain.