### PR TITLE
Remove black bar in nav, but Blog in main nav, move search to footer

### DIFF
--- a/_includes/global-footer.html
+++ b/_includes/global-footer.html
@@ -1,7 +1,13 @@
 <div class="global-footer" id="global-footer">
 
   <div class="layout-breve layout-tight">
-  
+
+    <form class="search-global" id="search-global" action="https://www.google.com/search" method="get" role="search">
+        <input type="search" id="search-global-input" class="search-global-input" autocomplete="off" placeholder="Search" name="q" />
+        <!-- consider applying autofocus="autofocus" to input -->
+        <button class="search-global-submit" id="search-global-submit" value="www.codeforamerica.org" type="submit" name="as_sitesearch">Search</button>
+    </form>
+
     <nav class="nav-footer" role="navigation">
       <ul>
         <li class="nav-tier1"><a class="nav-heading" href="/">Home</a></li>
@@ -20,7 +26,7 @@
             <li><a href="/contact/">Contact</a></li>
           </ul>
         </li>
-      
+
         <li class="nav-tier1"><a class="nav-heading" href="/governments/">Governments</a>
           <ul class="nav-tier2">
             <li><a href="/governments/albuquerque/">Albuquerque, NM</a></li>
@@ -46,7 +52,7 @@
             <li><a href="/geeks/civicissues">Civic Tech Issue Finder</a></li>
           </ul>
         </li>
-        
+
         <li class="nav-tier1"><a class="nav-heading" href="/geeks/">Companies</a>
           <ul class="nav-tier2">
             <li><a href="/companies/our-companies"> Our Companies</a></li>
@@ -55,7 +61,7 @@
             <li><a href="/companies/accelerator-apply">Apply</a></li>
           </ul>
         </li>
-        
+
            </li>
           <li class="nav-tier1"><a class="nav-heading" href="/our-work/">Our Work</a>
           <ul class="nav-tier2">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -38,34 +38,20 @@
     {% assign masthead = false %}
 {% endif %}
 
-{% if nav-global-primary != "no" %}
-<nav class="nav-global-primary">
-  <ul class="layout-breve layout-tight">
-    <li><a href="/blog">Blog</a></li>
-    <li><a href="/library">Library</a></li>
-    <li>
-      <form class="search-global" id="search-global" action="https://www.google.com/search" method="get" role="search">
-          <input type="search" id="search-global-input" class="search-global-input" autocomplete="off" placeholder="Search" name="q" />
-          <!-- consider applying autofocus="autofocus" to input -->
-          <button class="search-global-submit" id="search-global-submit" value="www.codeforamerica.org" type="submit" name="as_sitesearch">Search</button>
-      </form>
-    </li>
-  </ul>
-</nav>
-{% else %}
-<!--  
-      If we don't show the primary nav, we need an empty container so we can collapse the main nav on mobile screens
-      This requirement is because of the nav collapse functionality in global.js
-  -->
+{% comment %}
+      We previously had a nav-global-primary that has been removed. However, due
+      to a bug, if we don't show the primary nav, we need an empty container so
+      we can collapse the main nav on mobile screens. This requirement is because
+      of the nav collapse functionality in global.js.
+{% endcomment %}
 <nav class="nav-global-primary"></nav>
-{% endif %}
 
 {% if masthead != "no" %}
 <div class="masthead {{ masthead-class }}">
   <div class="masthead-hero">
-    <div class="masthead-image" 
+    <div class="masthead-image"
       {% if masthead-image %}
-      style="background-image: url('{{ masthead-image }}')" 
+      style="background-image: url('{{ masthead-image }}')"
       {% endif %}>
     </div>
   </div>
@@ -79,10 +65,10 @@
   {% comment %}
   Right now, we need to kill the margin-bottom on global-header if we have a custom masthead (since it comes after global-header)
   This checks if there's a custom masthead then applies a class we can style
-  In the future, this hack should be replaced with better pattern-portfolio styles for header above and below masthead 
+  In the future, this hack should be replaced with better pattern-portfolio styles for header above and below masthead
   {% endcomment %}
   {% if page.masthead-custom %}global-header-custom{% endif %}
-  ">  
+  ">
   <a href="/" class="global-header-logo">
       <img src="/assets/logo.png" />
   </a>
@@ -102,7 +88,7 @@
             <li><a href="/about/financial-information">Financial Information</a></li>
             <li><a href="/support-us/">Support Us</a></li>
             <li><a href="/jobs">Jobs</a></li>
-            <li><a href="/contact">Contact</a></li> 
+            <li><a href="/contact">Contact</a></li>
         </ul>
         {% endif %}
       </li>
@@ -152,18 +138,21 @@
         </ul>
         {% endif %}
       </li>
+      <li class="nav-tier1">
+        <a href="/blog">Blog</a>
+      </li>
       <li><a href="https://secure.codeforamerica.org/page/contribute/default?source_codes=nav-donate-button" class="button">Donate</a></li>
     </ul>
-  </nav>    
+  </nav>
 </div>
 
 {% if page.masthead-custom == "deep" %}
 <div class="masthead masthead-custom masthead-{{ page.masthead-custom }}">
-  
+
   <div class="masthead-hero">
-    <div class="masthead-image" 
+    <div class="masthead-image"
       {% if masthead-image %}
-      style="background-image: url('{{ masthead-image }}')" 
+      style="background-image: url('{{ masthead-image }}')"
       {% endif %}>
     </div>
   </div>
@@ -173,10 +162,10 @@
       <p class="page-overline">{{ page.title }}</p>
       <h1 class="page-title">{{ page.headline }}</h1>
     {% else %}
-      <h1 class="page-title">{{ page.title }}</h1>  
+      <h1 class="page-title">{{ page.title }}</h1>
     {% endif %}
   </header>
-  
+
   {% if page.description %}
   <div class="description layout-semibreve">
     <p class="page-description">{{ page.description }}</p>

--- a/stylesheets/staging.scss
+++ b/stylesheets/staging.scss
@@ -80,7 +80,12 @@ button.button-invert.white {
 	// Remove the border from the top of the global footer
 	border-top: none;
 	// Remove the top padding so our new signup box snaps to top
-	padding-top: 0;
+	// padding-top: 0;
+}
+
+.global-footer .search-global {
+	// this margin is messing up things
+	margin: 0;
 }
 
 nav.nav-footer {


### PR DESCRIPTION
We're changing up the top of the nav. (Description in the title of this PR.)

First step of this executed on the codeforamerica/pattern-library#8, which pulls our nav items closer together so they don't look wonky as the viewport shrinks. In #1207, we move our site to v3 of the pattern library so we can get these changes on codeforamerica.org.

This is the last step. We're banishing the black bar nav, moving blog into regular nav, moving search into footer.

There's still two issues to deal with going forward:

* We still need an empty .nav-global-primary container because of the wonky nav collapse function in global.js. Something to fix in the future.
* We have all kinds of code hanging around calling or not calling nav-global-primary in frontmatter around the site. This needs to be cleaned up later.