### PR TITLE
Add link to blog in Blogging for America header on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ helpers:
 
 <section class="slab-black slab-bg1" id="js-blogposts">
     <div class="layout-minim layout-solo insulate">
-        <h2 class="h5">Blogging [For America]</h2>
+        <h2 class="h5"><a href="/blog">Blogging [For America]</a></h2>
 
         <article class="post-preview">
             <header class="post-header isolate">
@@ -239,7 +239,7 @@ helpers:
 
     <section class="slab-black slab-bg1" id="js-blogposts">
         <div class="layout-minim layout-solo insulate">
-            <h2 class="h5">Blogging [For America]</h2>
+            <h2 class="h5"><a href="/blog">Blogging [For America]</a></h2>
 
             <article class="post-preview">
                 <header class="post-header isolate">


### PR DESCRIPTION
This should be a link. Now it is. :)

![image](https://cloud.githubusercontent.com/assets/6456757/8860191/1ea9ed6e-3137-11e5-8a33-87937f08bcde.png)
