### PR TITLE
Update headline, Add YouTube link

### DIFF
--- a/_includes/nav-summit-2015.html
+++ b/_includes/nav-summit-2015.html
@@ -103,7 +103,7 @@
           <a href="/summit/speakers/" {% if page.url == "/summit/speakers/index.html" %}class="active"{% endif %}>Speakers</a>
         </li>
         <li class="masthead-nav-page">
-          <a href="/library/tag/Summit+2014">2014 Summit Videos</a>
+          <a href="https://www.youtube.com/playlist?list=PL65XgbSILalWFStqV0z0N9pvftstJ8AAh">2014 Summit Videos</a>
         </li>
         <li class="masthead-nav-page">
           <a href="/summit/#register">Register</a>

--- a/summit/index.html
+++ b/summit/index.html
@@ -12,7 +12,7 @@ masthead-custom: "deep"
 title: "The CFA Summit"
 
 # Content for the custom deep masthead
-headline: "Transforming 21st Century Government"
+headline: "Transforming Government for the 21st Century"
 description: "September 30 - October 2, Oakland, California: The #CfASummit is a roll-up-your-sleeves conference that brings together innovators from hundreds of governments across the U.S. along with civic-minded technologists, designers, community organizers, and entrepreneurs."
 
 # Metadata image


### PR DESCRIPTION
Hi @davidrleonard:

Molly and I updated the headline on the Summit landing page to match the correct messaging. Also changed the 2014 Summit Videos link to go to YouTube instead of the Library because the Library looks like poo poo.

Please check and merge. thanks!