### PR TITLE
Allow email signup dialog to be customized

### DIFF
--- a/_includes/email-signup-form.html
+++ b/_includes/email-signup-form.html
@@ -1,15 +1,12 @@
 {% if include.context == 'footer' %}
-
 <form class="signup-global email-entry-form" action="//codeforamerica.us2.list-manage.com/subscribe/post?u=d9acf2a4c694efbd76a48936f&amp;id=3ac3aef1a5" name="mc-embedded-subscribe-form" method="post" target="_blank">
-  <h4><i class="icon-envelop"></i>Change your community. Join our email list.</h4>
+  <h4><i class="icon-envelop"></i>{% if page.helpers.email_signup.join_message %}{{page.helpers.email_signup.join_message}}{% else %}Change your community. Join our email list.{% endif %}</h4>
   <span class="combined">
     <input type="email" name="email" id="mce-email" placeholder="Enter your email address" />
     <input type="submit" value="Submit" class="button-invert text-whisper white" />
   </span>
 </form>
-
 {% else %}
-
 <form class="email-entry-form" action="//codeforamerica.us2.list-manage.com/subscribe/post?u=d9acf2a4c694efbd76a48936f&amp;id=3ac3aef1a5" method="post" target="_blank">
   <ul class="list-form">
     <li class="form-field">
@@ -18,5 +15,4 @@
     <input type="submit" value="Sign up" />
   </ul>
 </form>
-
 {% endif %}

--- a/_includes/email-signup-modal.html
+++ b/_includes/email-signup-modal.html
@@ -39,8 +39,18 @@ It serves as a confirm screen and data entry form for our global-footer mailing 
 							<li class="js-email-default-option">
 								<label for="mce-group[10273]-10273-2"><input type="checkbox" value="131072" name="group[10273][131072]" id="mce-group[10273]-10273-2" /> I am a technologist</label>
 							</li>
+							<!-- Other checkmarks that are possible -->
 							<li class="hidden js-economic-development-checkbox">
-								<label for="mce-group[10285]-10285-0"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-0" /> I'm interested in economic development</label>
+								<label for="mce-group[10285]-10285-0"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-0" /> I'm interested in Economic Development</label>
+							</li>
+							<li class="hidden js-health-and-human-services-checkbox">
+								<label for="mce-group[10285]-10285-1"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-1" /> I'm interested in Health and Human Services</label>
+							</li>
+							<li class="hidden js-safety-and-justice-checkbox">
+								<label for="mce-group[10285]-10285-2"><input type="checkbox" value="1073741824" name="group[10285][1073741824]" id="mce-group[10285]-10285-2" /> I'm interested in Safety and Justice</label>
+							</li>
+							<li class="hidden js-communications-and-engagement-checkbox">
+								<label for="mce-group[10285]-10285-3"><input type="checkbox" value="4294967296" name="group[10285][4294967296]" id="mce-group[10285]-10285-3" /> I'm interested in Communications and Engagement</label>
 							</li>
 						</div>
 						<input type="hidden" value="{{ page.url }}" name="REFERRAL" style="display:none;" id="mce-REFERRAL">

--- a/_includes/email-signup-modal.html
+++ b/_includes/email-signup-modal.html
@@ -52,17 +52,17 @@ It serves as a confirm screen and data entry form for our global-footer mailing 
 								<label for="mce-group[10273]-10273-2"><input type="checkbox" value="131072" name="group[10273][131072]" id="mce-group[10273]-10273-2" /> I am a technologist</label>
 							</li>
 							<!-- Other checkmarks that are possible -->
-							<li class="{% unless page.helpers.show_group == 'economic-development' %}hidden{% endunless %} js-economic-development-checkbox">
-								<label for="mce-group[10285]-10285-0"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-0" {% if page.helpers.show_group == 'economic-development' %}checked{% endif %} /> I'm interested in Economic Development</label>
+							<li class="{% unless page.helpers.email_signup.show_group == 'economic-development' %}hidden{% endunless %} js-economic-development-checkbox">
+								<label for="mce-group[10285]-10285-0"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-0" {% if page.helpers.email_signup.show_group == 'economic-development' %}checked{% endif %} /> I'm interested in Economic Development</label>
 							</li>
-							<li class="{% unless page.helpers.show_group == 'health-and-human-services' %}hidden{% endunless %} js-health-and-human-services-checkbox">
-								<label for="mce-group[10285]-10285-1"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-1" {% if page.helpers.show_group == 'health-and-human-services' %}checked{% endif %} /> I'm interested in Health and Human Services</label>
+							<li class="{% unless page.helpers.email_signup.show_group == 'health-and-human-services' %}hidden{% endunless %} js-health-and-human-services-checkbox">
+								<label for="mce-group[10285]-10285-1"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-1" {% if page.helpers.email_signup.show_group == 'health-and-human-services' %}checked{% endif %} /> I'm interested in Health and Human Services</label>
 							</li>
-							<li class="{% unless page.helpers.show_group == 'safety-and-justice' %}hidden{% endunless %} js-safety-and-justice-checkbox">
-								<label for="mce-group[10285]-10285-2"><input type="checkbox" value="1073741824" name="group[10285][1073741824]" id="mce-group[10285]-10285-2" {% if page.helpers.show_group == 'safety-and-justice' %}checked{% endif %} /> I'm interested in Safety and Justice</label>
+							<li class="{% unless page.helpers.email_signup.show_group == 'safety-and-justice' %}hidden{% endunless %} js-safety-and-justice-checkbox">
+								<label for="mce-group[10285]-10285-2"><input type="checkbox" value="1073741824" name="group[10285][1073741824]" id="mce-group[10285]-10285-2" {% if page.helpers.email_signup.show_group == 'safety-and-justice' %}checked{% endif %} /> I'm interested in Safety and Justice</label>
 							</li>
-							<li class="{% unless page.helpers.show_group == 'communications-and-engagement' %}hidden{% endunless %} js-communications-and-engagement-checkbox">
-								<label for="mce-group[10285]-10285-3"><input type="checkbox" value="4294967296" name="group[10285][4294967296]" id="mce-group[10285]-10285-3" {% if page.helpers.show_group == 'communications-and-engagement' %}checked{% endif %} /> I'm interested in Communications and Engagement</label>
+							<li class="{% unless page.helpers.email_signup.show_group == 'communications-and-engagement' %}hidden{% endunless %} js-communications-and-engagement-checkbox">
+								<label for="mce-group[10285]-10285-3"><input type="checkbox" value="4294967296" name="group[10285][4294967296]" id="mce-group[10285]-10285-3" {% if page.helpers.email_signup.show_group == 'communications-and-engagement' %}checked{% endif %} /> I'm interested in Communications and Engagement</label>
 							</li>
 						</div>
 						<input type="hidden" value="{{ page.url }}" name="REFERRAL" style="display:none;" id="mce-REFERRAL">

--- a/_includes/email-signup-modal.html
+++ b/_includes/email-signup-modal.html
@@ -9,8 +9,20 @@ It serves as a confirm screen and data entry form for our global-footer mailing 
 		<div class="modal-backdrop"></div>
 		<section class="modal-dialog">
 			<div class="modal-content">
-				<h2 id="js-modal-headline">Help us send you great stuff</h2>
-				<p id="js-modal-description">We'll use this information to send you interesting news, tools and updates.</p>
+				<h2 id="js-modal-headline">
+					{% if page.helpers.email_signup.headline %}
+						{{page.helpers.email_signup.headline}}
+					{% else %}
+						Help us send you great stuff
+					{% endif %}
+				</h2>
+				<p id="js-modal-description">
+					{% if page.helpers.email_signup.description %}
+						{{page.helpers.email_signup.description}}
+					{% else %}
+						We'll use this information to send you interesting news, tools and updates.
+					{% endif %}
+				</p>
 				<p id="email-signup-error" class="alert-failure" style="display:none;"></p>
 				<form id="email-signup-data-form" action="//codeforamerica.us2.list-manage.com/subscribe/post-json?u=d9acf2a4c694efbd76a48936f&amp;id=3ac3aef1a5&c=?" method="get">
 					<ul class="list-form">
@@ -40,17 +52,17 @@ It serves as a confirm screen and data entry form for our global-footer mailing 
 								<label for="mce-group[10273]-10273-2"><input type="checkbox" value="131072" name="group[10273][131072]" id="mce-group[10273]-10273-2" /> I am a technologist</label>
 							</li>
 							<!-- Other checkmarks that are possible -->
-							<li class="hidden js-economic-development-checkbox">
-								<label for="mce-group[10285]-10285-0"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-0" /> I'm interested in Economic Development</label>
+							<li class="{% unless page.helpers.show_group == 'economic-development' %}hidden{% endunless %} js-economic-development-checkbox">
+								<label for="mce-group[10285]-10285-0"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-0" {% if page.helpers.show_group == 'economic-development' %}checked{% endif %} /> I'm interested in Economic Development</label>
 							</li>
-							<li class="hidden js-health-and-human-services-checkbox">
-								<label for="mce-group[10285]-10285-1"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-1" /> I'm interested in Health and Human Services</label>
+							<li class="{% unless page.helpers.show_group == 'health-and-human-services' %}hidden{% endunless %} js-health-and-human-services-checkbox">
+								<label for="mce-group[10285]-10285-1"><input type="checkbox" value="536870912" name="group[10285][536870912]" id="mce-group[10285]-10285-1" {% if page.helpers.show_group == 'health-and-human-services' %}checked{% endif %} /> I'm interested in Health and Human Services</label>
 							</li>
-							<li class="hidden js-safety-and-justice-checkbox">
-								<label for="mce-group[10285]-10285-2"><input type="checkbox" value="1073741824" name="group[10285][1073741824]" id="mce-group[10285]-10285-2" /> I'm interested in Safety and Justice</label>
+							<li class="{% unless page.helpers.show_group == 'safety-and-justice' %}hidden{% endunless %} js-safety-and-justice-checkbox">
+								<label for="mce-group[10285]-10285-2"><input type="checkbox" value="1073741824" name="group[10285][1073741824]" id="mce-group[10285]-10285-2" {% if page.helpers.show_group == 'safety-and-justice' %}checked{% endif %} /> I'm interested in Safety and Justice</label>
 							</li>
-							<li class="hidden js-communications-and-engagement-checkbox">
-								<label for="mce-group[10285]-10285-3"><input type="checkbox" value="4294967296" name="group[10285][4294967296]" id="mce-group[10285]-10285-3" /> I'm interested in Communications and Engagement</label>
+							<li class="{% unless page.helpers.show_group == 'communications-and-engagement' %}hidden{% endunless %} js-communications-and-engagement-checkbox">
+								<label for="mce-group[10285]-10285-3"><input type="checkbox" value="4294967296" name="group[10285][4294967296]" id="mce-group[10285]-10285-3" {% if page.helpers.show_group == 'communications-and-engagement' %}checked{% endif %} /> I'm interested in Communications and Engagement</label>
 							</li>
 						</div>
 						<input type="hidden" value="{{ page.url }}" name="REFERRAL" style="display:none;" id="mce-REFERRAL">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -94,7 +94,7 @@ nav-breadcrumbs:
       <main role="main">
         {{ content }}
 
-        {% unless page.mailing-list-header %}
+        {% unless page.hide-mailing-list-footer %}
         <!-- Email signup form -->
         <div class="slab-medium-red">
           <div class="layout-breve layout-tight">

--- a/our-work/focus-areas/economic-development/index.html
+++ b/our-work/focus-areas/economic-development/index.html
@@ -14,11 +14,16 @@ title: Economic Development Focus Area
 headline: Delivering core economic development services, promoting inclusive economic opportunities
 description: Code for America partners with local governments to build and grow digital economic development services focused on inclusive opportunities, helping governments transform themselves along the way.
 
-# Blogpost helpers
+# Generic helpers
 helpers:
   blogpost:
     category: economic-development
     max_post_count: 4
+  email_signup:
+    headline: "I'm interested in Economic Development"
+    description: "Want to learn more about what Code for America is doing to promote inclusive economic growth? Join our email list to help inform Code for America's work in this area."
+    join_message: "Get updates on our Economic Development work. Join our email list."
+    show_group: "economic-development"
 ---
 <style>
 	* + section {

--- a/our-work/focus-areas/economic-development/index.html
+++ b/our-work/focus-areas/economic-development/index.html
@@ -19,7 +19,6 @@ helpers:
   blogpost:
     category: economic-development
     max_post_count: 4
-
 ---
 <style>
 	* + section {
@@ -42,7 +41,7 @@ helpers:
 		<p>Code for America works across a wide variety of teams who contribute to these outcomes—including municipal economic development departments, public-private economic development corporations, redevelopment authorities, and non-profit organizations. Together, we develop digital services that measurably improve economic opportunity, and help these teams retool their ways of delivering services to be more effective in the digital world.</p>
 
     <p><strong>Want to learn more about what Code for America is doing to promote inclusive economic growth? Join our email list help inform Code for America’s work in this area.</strong></p>
-    <p><a href="#" class="js-modal-show js-email-economic-development button button-l button-bold">Sign up</a></p>
+    <p><a href="#" class="button button-l button-bold" data-email-signup-button="true" data-email-headline="I'm interested in Economic Development" data-email-description="Want to learn more about what Code for America is doing to promote inclusive economic growth? Join our email list help inform Code for America's work in this area." data-email-only-show-group="economic-development">Sign up</a></p>
 	</div><!-- end .layout-major-invert -->
 
 	<div class="layout-minim" style="width:46%; padding-left: 4%;">

--- a/script/email-signup.js
+++ b/script/email-signup.js
@@ -34,7 +34,7 @@ var showModal = function(submittedEmail,elem) {
 		}
 		// Do they want to show a specific checkbox and hide all others?
 		if (hasAttr(elem,'data-email-only-show-group') ) {
-			var theClass = '.' + $(elem).attr('data-email-only-show-group');
+			var theClass = '.js-' + $(elem).attr('data-email-only-show-group') + '-checkbox';
 			if ($(theClass).hasClass('hidden')) {
 				$(theClass).toggleClass('hidden');
 				$(theClass).find('input').prop('checked',true);

--- a/script/email-signup.js
+++ b/script/email-signup.js
@@ -1,9 +1,18 @@
-/**
+	/**
 *
 * email-signup.js
 * This JS helps our newsletter email signup, which is now in the footer on every page. It relies in jQuery.
 *
 **/
+
+var hasAttr = function(elem,attrib) {
+	if (typeof($(elem).attr(attrib)) !== "undefined" && $(elem).attr(attrib) !== "") {
+		return true;
+	}
+	else {
+		return false;
+	}
+}
 
 var showModal = function(submittedEmail,elem) {
 	// If the body has a modal class, we've already shown the modal
@@ -15,13 +24,20 @@ var showModal = function(submittedEmail,elem) {
 	}
 	// If there's an elem, they clicked a button ... check it to do things
 	if (typeof(elem) !== "undefined" && elem !== "") {
-		// If this is an economic development button, show special things
-		if ($(elem).hasClass('js-email-economic-development')) {
-			$('#js-modal-headline').text('I\'m interested in Economic Development');
-			$('#js-modal-description').text('Want to learn more about what Code for America is doing to promote inclusive economic growth? Join our email list help inform Code for America\'s work in this area.');
-			if ($('.js-economic-development-checkbox').hasClass('hidden')) {
-				$('.js-economic-development-checkbox').toggleClass('hidden');
-				$('.js-economic-development-checkbox').find('input').prop('checked',true);
+		// Do they want a custom headline?
+		if (hasAttr(elem,'data-email-headline') ) {
+			$('#js-modal-headline').text($(elem).attr('data-email-headline'));
+		}
+		// Do they want a custom description?
+		if (hasAttr(elem,'data-email-description') ) {
+			$('#js-modal-description').text($(elem).attr('data-email-description'));
+		}
+		// Do they want to show a specific checkbox and hide all others?
+		if (hasAttr(elem,'data-email-only-show-group') ) {
+			var theClass = '.' + $(elem).attr('data-email-only-show-group');
+			if ($(theClass).hasClass('hidden')) {
+				$(theClass).toggleClass('hidden');
+				$(theClass).find('input').prop('checked',true);
 			}
 			$.each($('.js-email-default-option'), function(index,option){
 				if (!$(option).hasClass('hidden')) {
@@ -130,8 +146,9 @@ $(document).ready(function() {
 	// When the modal is visible and the user clicks anywhere else on the page, close it
 	$(document).on('click', function(e) {
     // If the user is trying to show the modal, show it, don't hide it
-    if ($(e.target).hasClass("js-modal-show")) {
-      showModal();
+    // if ($(e.target).hasClass("js-modal-show")) {
+		if (hasAttr(e.target,'data-email-signup-button')) {
+      showModal('',e.target);
       e.preventDefault();
       return;
     }

--- a/signup/index.html
+++ b/signup/index.html
@@ -8,7 +8,7 @@ nav-global-primary: "no"
 masthead-custom: deep
 
 # Hide the default mailing list, embed it below the description
-mailing-list-header: true
+hide-mailing-list-footer: true
 
 # Title for the title bar, and the overline in the masthead
 title: Mailing list signup


### PR DESCRIPTION
We have a need to allow for complex customizations in our email signup modal. As we bring focus-area specific mailing list groups online, each one will need custom signup options in various places throughout the site.

Here are the new choices for launching an email signup flow:

# With a "button"

You can spawn an email signup modal with whatever data by creating an anchor link (or button, or any other clickable thing) with the correct data attributes.

Here's an example from the Economic Development page:

```
<a href="#" class="button button-l button-bold" data-email-signup-button="true" data-email-headline="I'm interested in Economic Development" data-email-description="Want to learn more about what Code for America is doing to promote inclusive economic growth? Join our email list help inform Code for America's work in this area." data-email-only-show-group="economic-development">Sign up</a>
```

The data attributes used here are:

* `data-email-signup-button=""` (boolean): This binds a click event to the button that triggers the modal to pop up when it's clicked. It also prevents the default action of opening whatever the anchor link's href="" value is. If you want it to work, set the value to "true".
* `data-email-headline=""` (string): A headline that will appear at the top of the email signup modal.
* `data-email-description=""` (string): A description that appears at the top of the email signup modal.
* `data-email-only-show-group=""` (string with strict requirements): Hides all group options on the email modal except the one referenced. Should be one of the following allowable values: `safety-and-justice`, `economic-development`, `health-and-human-services`, `communications-and-engagement`

Here's what our example button will look like rendered on the page:

![image](https://cloud.githubusercontent.com/assets/6456757/10089799/d032586a-62dc-11e5-887c-66283b0ee306.png)

Here's the email modal it will trigger:

![image](https://cloud.githubusercontent.com/assets/6456757/10089816/062a6a2a-62dd-11e5-9382-c636bda8e75d.png)

# With page frontmatter

The frontmatter on each page (the stuff at the top between the `---` marks at the top of the page) now has a new helper option. This helper, called `email_signup`, allows each page to have its own email signup modal text.

Here are the options (note, they're white-space sensitive because it's YAML):

```
helpers:
  email_signup:
    headline: "I'm interested in Economic Development"
    description: "Want to learn more about what Code for America is doing to promote inclusive economic growth? Join our email list to help inform Code for America's work in this area."
    join_message: "Get updates on our Economic Development work. Join our email list."
    show_group: "economic-development"
```

The available fields are:

* `headline` (string): A headline that will appear at the top of the email signup modal.
* `description` (string): A description that will appear at the top of the email signup modal.
* `join_message` (string): A message that will appear beside the email signup box at the bottom of the page.
* `show_group` (string with strict requirements): Shows the email signup group referenced. Should be one of the following allowable values: `safety-and-justice`, `economic-development`, `health-and-human-services`, `communications-and-engagement`

Here's the form that will create:

![image](https://cloud.githubusercontent.com/assets/6456757/10089907/06cb2a2c-62de-11e5-99c8-cda2bece44df.png)

Here's the email signup modal it will create:

![image](https://cloud.githubusercontent.com/assets/6456757/10089924/24d809cc-62de-11e5-922a-f708061f8fb0.png)
