### PR TITLE
Add logo alt text

### DIFF
--- a/_includes/global-footer.html
+++ b/_includes/global-footer.html
@@ -100,7 +100,7 @@
 <div class="global-foot" role="contentinfo">
   <div class="layout-tight layout-breve">
     <div class="global-foot-content">
-      <img class="global-foot-logo" src="/assets/logo-inversed.png" />
+      <img class="global-foot-logo" src="/assets/logo-inversed.png" alt="Code for America logo" />
       <small>Code for America Labs, Inc is a non-partisan, non-political 501(c)(3) organization. EIN number 27-1067272. Content is licensed through Creative Commons.<br/>
       Provide website feedback <a href="https://github.com/codeforamerica/codeforamerica.org/issues/new">on GitHub</a> or to <a href="mailto:info@codeforamerica.org">info@codeforamerica.org</a>.</small>
     </div>

--- a/_includes/nav-speakers.html
+++ b/_includes/nav-speakers.html
@@ -45,7 +45,7 @@
 
 <div class="global-header">
   <a href="/" class="global-header-logo">
-      <img src="/assets/logo.png" />
+      <img src="/assets/logo.png" alt="Code for America logo" />
   </a>
   <p class="skip-to-nav"><a href="#global-footer">Menu</a></p>
 

--- a/_includes/nav-summit.html
+++ b/_includes/nav-summit.html
@@ -21,7 +21,7 @@
 
 <!--div class="global-header-compact" role="banner">
   <a href="" class="global-header-logo">
-      <img src="/assets/logo.png" />
+      <img src="/assets/logo.png" alt="Code for America logo" />
   </a>
 
   <p class="global-header-tagline">Bringing together <strong>local governments</strong> and <strong>technologists</strong> <br />to make <strong>better cities for everyone</strong>
@@ -32,7 +32,7 @@
 
   <nav class="nav-global-secondary">
     <ul>
-      
+
       <li><a href="http://old.cfasummit.org" class="button">Past events</a></li>
     </ul>
   </nav>
@@ -45,18 +45,18 @@
   </header>
 </div>
 
-<div class="global-header">  
+<div class="global-header">
   <a href="/" class="global-header-logo">
-      <img src="/assets/logo.png">
+      <img src="/assets/logo.png" alt="Code for America logo" >
   </a>
   <p class="skip-to-nav"><a href="#global-footer">Menu</a></p>
 
-      
+
   <nav class="nav-global-secondary">
     <ul>
         <li class="nav-tier1 nav-has-children">
             <a href="/summit/2014/" {% if nav_tier1_active == "about" %}class="state-active"{% endif %}>2014 About</a>
-        
+
             {% if nav_tier1_active == "about" %}
             <ul class="nav-tier2">
                 <li><a href="/summit/2014/venue">2014 Venue</a></li>
@@ -73,7 +73,7 @@
         </li>
         <li class="nav-tier1 nav-has-children">
             <a href="/summit/2014/sponsors" {% if nav_tier1_active == "sponsors" %}class="state-active"{% endif %}>2014 Sponsors</a>
-        
+
             {% if nav_tier1_active == "sponsors" %}
             <ul class="nav-tier2">
                 <li><a href="/media/docs/2014summitoverview.pdf">Prospectus</a></li>
@@ -84,5 +84,5 @@
             <a href="/library/tag/Summit+2014" class="button">Watch the 2014 Videos</a>
         </li>
     </ul>
-  </nav>    
+  </nav>
 </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -70,7 +70,7 @@
   {% if page.masthead-custom %}global-header-custom{% endif %}
   ">
   <a href="/" class="global-header-logo">
-      <img src="/assets/logo.png" />
+      <img src="/assets/logo.png" alt="Code for America logo" />
   </a>
   <p class="skip-to-nav"><a href="#global-footer">Menu</a></p>
 

--- a/_includes/summit-footer.html
+++ b/_includes/summit-footer.html
@@ -5,7 +5,7 @@
 <div class="global-foot" role="contentinfo">
   <div class="layout-tight layout-breve">
     <div class="global-foot-content">
-      <img class="global-foot-logo" src="/assets/logo-inversed.png" />
+      <img class="global-foot-logo" src="/assets/logo-inversed.png" alt="Code for America logo" />
       <small>Code for America Labs, Inc is a non-partisan, non-political 501(c)(3) organization. Content is licensed through Creative Commons.<br/>
       Provide website feedback <a href="https://github.com/codeforamerica/codeforamerica.org/issues/new">on GitHub</a> or to <a href="mailto:info@codeforamerica.org">info@codeforamerica.org</a>.</small>
     </div>

--- a/governments/atlantis/index.html
+++ b/governments/atlantis/index.html
@@ -201,7 +201,7 @@ nav-breadcrumbs:
 <div class="global-foot" role="contentinfo">
   <div class="layout-tight layout-breve">
     <div class="global-foot-content">
-      <img class="global-foot-logo" src="/assets/logo-inversed.png" />
+      <img class="global-foot-logo" src="/assets/logo-inversed.png" alt="Code for America logo" />
       <small>Code for America Labs, Inc is a non-partisan, non-political 501(c)(3) organization. Content is licensed through Creative Commons.</small>
     </div>
   </div>

--- a/governments/emeraldcity/index.html
+++ b/governments/emeraldcity/index.html
@@ -157,7 +157,7 @@ nav-breadcrumbs:
 <div class="global-foot" role="contentinfo">
   <div class="layout-tight layout-breve">
     <div class="global-foot-content">
-      <img class="global-foot-logo" src="/assets/logo-inversed.png" />
+      <img class="global-foot-logo" src="/assets/logo-inversed.png" alt="Code for America logo" />
       <small>Code for America Labs, Inc is a non-partisan, non-political 501(c)(3) organization. Content is licensed through Creative Commons.</small>
     </div>
   </div>

--- a/peer-network-training/fakefolder/index.html
+++ b/peer-network-training/fakefolder/index.html
@@ -89,7 +89,7 @@
 
 <div class="global-header">  
   <a href="/" class="global-header-logo">
-      <img src="/assets/logo.png" />
+      <img src="/assets/logo.png" alt="Code for America logo" />
   </a>
   <p class="skip-to-nav"><a href="#global-footer">Menu</a></p>
 
@@ -270,7 +270,7 @@ This event will air on March 20, 2014 at 10am PT.
 <div class="global-foot" role="contentinfo">
   <div class="layout-tight layout-breve">
     <div class="global-foot-content">
-      <img class="global-foot-logo" src="/assets/logo-inversed.png" />
+      <img class="global-foot-logo" src="/assets/logo-inversed.png" alt="Code for America logo" />
       <small>Code for America Labs, Inc is a non-partisan, non-political 501(c)(3) organization. Content is licensed through Creative Commons.</small>
     </div>
   </div>

--- a/summit/2014/submit/index.html
+++ b/summit/2014/submit/index.html
@@ -58,7 +58,7 @@
 
 <!--div class="global-header-compact" role="banner">
   <a href="" class="global-header-logo">
-      <img src="/assets/logo.png" />
+      <img src="/assets/logo.png" alt="Code for America logo" />
   </a>
 
   <p class="global-header-tagline">Bringing together <strong>local governments</strong> and <strong>technologists</strong> <br />to make <strong>better cities for everyone</strong>
@@ -69,7 +69,7 @@
 
   <nav class="nav-global-secondary">
     <ul>
-      
+
       <li><a href="http://old.cfasummit.org" class="button">Past events</a></li>
     </ul>
   </nav>
@@ -82,13 +82,13 @@
   </header>
 </div>
 
-<div class="global-header">  
+<div class="global-header">
   <a href="/" class="global-header-logo">
-      <img src="/assets/logo.png">
+      <img src="/assets/logo.png" alt="Code for America logo">
   </a>
   <p class="skip-to-nav"><a href="#global-footer">Menu</a></p>
 
-      
+
   <nav class="nav-global-secondary">
     <ul>
         <li class="nav-tier1 nav-has-children">
@@ -111,29 +111,29 @@
         </li>
         <li><a href="https://codeforamerica.wufoo.com/forms/2014-cfa-summit-propose-a-session/" class="button">Propose a Session</a></li>
     </ul>
-  </nav>    
+  </nav>
 </div>
 <main role="main">
     <section class="layout-semibreve layout-centered intro">
-    
+
         <h2 class="h3">Submit a proposal</h2>
 
     </section>
     <section class="layout-semibreve">
         <p>The Summit is an annual gathering of civic technology leaders — ranging from Mayors to entrepreneurs, from community organizers to CTOs — who hold a shared belief that together we can create a government by the people, for the people works for us all in the 21st century.</p>
-        
+
         <p>What started as a way to bring together our distributed and ever-expanding network has grown into the annual event where forward-thinking technologists, government officials, and community advocates convene to exchange ideas, explore new ways to solve problems, and identify best practices for improving the way government works. More than 80 cities were represented at last year’s event.</p>
-        
+
         <p>This year's event will bring together even more cities and civic-minded citizens for two half days of main-stage content, breakout session, and working groups.</p>
 
         <section class="layout-semibreve layout-centered">
-    
+
             <h2 class="h3">Stay tuned for more information on registration.</h2>
 
         </section>
     </section>
 
-    
+
 
 
 

--- a/valentine/testimonial/index.html
+++ b/valentine/testimonial/index.html
@@ -83,7 +83,7 @@
 
 <div class="global-header">  
   <a href="/" class="global-header-logo">
-      <img src="/assets/logo.png" />
+      <img src="/assets/logo.png" alt="Code for America logo" />
   </a>
   <p class="skip-to-nav"><a href="#global-footer">Menu</a></p>
 
@@ -399,7 +399,7 @@
 <div class="global-foot" role="contentinfo">
   <div class="layout-tight layout-breve">
     <div class="global-foot-content">
-      <img class="global-foot-logo" src="/assets/logo-inversed.png" />
+      <img class="global-foot-logo" src="/assets/logo-inversed.png" alt="Code for America logo" />
       <small>Code for America Labs, Inc is a non-partisan, non-political 501(c)(3) organization. Content is licensed through Creative Commons.</small>
     </div>
   </div>


### PR DESCRIPTION
#1434 points out we don't have alt text on our header/footer logos. Bad accessibility, us. :( This PR fixes that by adding appropriate alt text. 

Thanks @bobprokop for pointing this out.