### PR TITLE
Remove "Load More" Buttons - #790

### DIFF
--- a/products/citizen-engagement.html
+++ b/products/citizen-engagement.html
@@ -69,7 +69,6 @@ nav-breadcrumbs:
 	</li>
 </ul>
 
-            <p class="layout-centered isolate"><a href="#" class="button button-subtle button-crotchet text-whisper">Load More</a></p>
         </div>
     </div>
     </div>

--- a/products/free.html
+++ b/products/free.html
@@ -94,7 +94,6 @@ nav-breadcrumbs:
 
 </ul>
 
-            <p class="layout-centered isolate"><a href="#" class="button button-subtle button-crotchet text-whisper">Load More</a></p>
         </div>
     </div>
     </div>

--- a/products/local-service.html
+++ b/products/local-service.html
@@ -81,7 +81,6 @@ nav-breadcrumbs:
 	</li>
 </ul>
 
-            <p class="layout-centered isolate"><a href="#" class="button button-subtle button-crotchet text-whisper">Load More</a></p>
         </div>
     </div>
     </div>

--- a/products/paid.html
+++ b/products/paid.html
@@ -83,7 +83,6 @@ nav-breadcrumbs:
 	</li>
 </ul>
 
-            <p class="layout-centered isolate"><a href="#" class="button button-subtle button-crotchet text-whisper">Load More</a></p>
         </div>
     </div>
     </div>


### PR DESCRIPTION
Fixes issue #790. These buttons weren’t hooked up to any JavaScript and
were causing the page to jump back to the top when clicked.